### PR TITLE
refactor: simplify undo_edit command

### DIFF
--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -82,8 +82,6 @@ class OHEditor:
         """
         Implement the str_replace command, which replaces old_str with new_str in the file content.
         """
-        self._populate_file_history_if_having_content_before_edit(path)
-
         file_content = self.read_file(path)
         old_str = old_str.expandtabs()
         new_str = new_str.expandtabs() if new_str is not None else ''
@@ -112,7 +110,7 @@ class OHEditor:
         self.write_file(path, new_file_content)
 
         # Save the content to history
-        self._file_history[path].append(new_file_content)
+        self._file_history[path].append(file_content)
 
         # Create a snippet of the edited section
         replacement_line = file_content.split(old_str)[0].count('\n')
@@ -204,8 +202,6 @@ class OHEditor:
         """
         Implement the insert command, which inserts new_str at the specified line in the file content.
         """
-        self._populate_file_history_if_having_content_before_edit(path)
-
         try:
             file_text = self.read_file(path)
         except Exception as e:
@@ -241,7 +237,7 @@ class OHEditor:
         snippet = '\n'.join(snippet_lines)
 
         self.write_file(path, new_file_text)
-        self._file_history[path].append(new_file_text)
+        self._file_history[path].append(file_text)
 
         success_message = f'The file {path} has been edited. '
         success_message += self._make_output(
@@ -284,25 +280,14 @@ class OHEditor:
                 f'The path {path} is a directory and only the `view` command can be used on directories.',
             )
 
-    def _populate_file_history_if_having_content_before_edit(self, path: Path) -> None:
-        """
-        Populate the file history with the current file content.
-        """
-        # Check if the file exists or history is not empty
-        if len(self._file_history[path]) > 0 or not path.exists():
-            return
-
-        self._file_history[path].append(self.read_file(path))
-
     def undo_edit(self, path: Path) -> CLIResult:
         """
         Implement the undo_edit command.
         """
-        if not self._file_history[path] or len(self._file_history[path]) <= 1:
+        if not self._file_history[path]:
             raise ToolError(f'No edit history found for {path}.')
 
-        self._file_history[path].pop()
-        old_text = self._file_history[path][-1]
+        old_text = self._file_history[path].pop()
         self.write_file(path, old_text)
 
         return CLIResult(


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR is to:
- Simplify the existing `undo_edit` implementation.

This branch is what we used for eval in OpenHands.
