### PR TITLE
Port linter and integrate linter into the file editor

### DIFF
--- a/openhands_aci/editor/__init__.py
+++ b/openhands_aci/editor/__init__.py
@@ -22,6 +22,7 @@ def file_editor(
     old_str: str | None = None,
     new_str: str | None = None,
     insert_line: int | None = None,
+    enable_linting: bool = False,
 ) -> str:
     try:
         result = _GLOBAL_EDITOR(
@@ -32,6 +33,7 @@ def file_editor(
             old_str=old_str,
             new_str=new_str,
             insert_line=insert_line,
+            enable_linting=enable_linting,
         )
     except ToolError as e:
         return _make_api_tool_result(ToolResult(error=e.message))

--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -2,6 +2,8 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Literal, get_args
 
+from openhands_aci.utils.shell import run_shell_cmd
+
 from .config import SNIPPET_CONTEXT_WINDOW
 from .exceptions import (
     EditorToolParameterInvalidError,
@@ -9,7 +11,6 @@ from .exceptions import (
     ToolError,
 )
 from .results import CLIResult, ToolResult, maybe_truncate
-from .shell import run_shell_cmd
 
 Command = Literal[
     'view',

--- a/openhands_aci/linter/__init__.py
+++ b/openhands_aci/linter/__init__.py
@@ -1,0 +1,9 @@
+"""Linter module for OpenHands ACI.
+
+Part of this Linter module is adapted from Aider (Apache 2.0 License, [original code](https://github.com/paul-gauthier/aider/blob/main/aider/linter.py)). Please see the [original repository](https://github.com/paul-gauthier/aider) for more information.
+"""
+
+from .base import LintResult
+from .linter import DefaultLinter
+
+__all__ = ['DefaultLinter', 'LintResult']

--- a/openhands_aci/linter/base.py
+++ b/openhands_aci/linter/base.py
@@ -1,0 +1,79 @@
+from abc import ABC, abstractmethod
+
+from pydantic import BaseModel
+
+
+class LintResult(BaseModel):
+    file: str
+    line: int  # 1-indexed
+    column: int  # 1-indexed
+    message: str
+
+    def visualize(self, half_window: int = 3) -> str:
+        """Visualize the lint result by print out all the lines where the lint result is found.
+
+        Args:
+            half_window: The number of context lines to display around the error on each side.
+        """
+        with open(self.file, 'r') as f:
+            file_lines = f.readlines()
+
+        # Add line numbers
+        _span_size = len(str(len(file_lines)))
+        file_lines = [
+            f'{i + 1:>{_span_size}}|{line.rstrip()}'
+            for i, line in enumerate(file_lines)
+        ]
+
+        # Get the window of lines to display
+        assert self.line <= len(file_lines) and self.line > 0
+        line_idx = self.line - 1
+        begin_window = max(0, line_idx - half_window)
+        end_window = min(len(file_lines), line_idx + half_window + 1)
+
+        selected_lines = file_lines[begin_window:end_window]
+        line_idx_in_window = line_idx - begin_window
+
+        # Add character hint
+        _character_hint = (
+            _span_size * ' '
+            + ' ' * (self.column)
+            + '^'
+            + ' ERROR HERE: '
+            + self.message
+        )
+        selected_lines[line_idx_in_window] = (
+            f'\033[91m{selected_lines[line_idx_in_window]}\033[0m'
+            + '\n'
+            + _character_hint
+        )
+        return '\n'.join(selected_lines)
+
+
+class LinterException(Exception):
+    """Base class for all linter exceptions."""
+
+    pass
+
+
+class BaseLinter(ABC):
+    """Base class for all linters.
+
+    Each linter should be able to lint files of a specific type and return a list of (parsed) lint results.
+    """
+
+    encoding: str = 'utf-8'
+
+    @property
+    @abstractmethod
+    def supported_extensions(self) -> list[str]:
+        """The file extensions that this linter supports, such as .py or .tsx."""
+        return []
+
+    @abstractmethod
+    def lint(self, file_path: str) -> list[LintResult]:
+        """Lint the given file.
+
+        file_path: The path to the file to lint. Required to be absolute.
+        """
+        pass

--- a/openhands_aci/linter/impl/treesitter.py
+++ b/openhands_aci/linter/impl/treesitter.py
@@ -1,0 +1,74 @@
+import warnings
+
+from grep_ast import TreeContext, filename_to_lang
+from grep_ast.parsers import PARSERS
+from tree_sitter_languages import get_parser
+
+from ..base import BaseLinter, LintResult
+
+# tree_sitter is throwing a FutureWarning
+warnings.simplefilter('ignore', category=FutureWarning)
+
+
+def tree_context(fname, code, line_nums):
+    context = TreeContext(
+        fname,
+        code,
+        color=False,
+        line_number=True,
+        child_context=False,
+        last_line=False,
+        margin=0,
+        mark_lois=True,
+        loi_pad=3,
+        # header_max=30,
+        show_top_of_file_parent_scope=False,
+    )
+    line_nums = set(line_nums)
+    context.add_lines_of_interest(line_nums)
+    context.add_context()
+    output = context.format()
+    return output
+
+
+def traverse_tree(node):
+    """Traverses the tree to find errors."""
+    errors = []
+    if node.type == 'ERROR' or node.is_missing:
+        line_no = node.start_point[0] + 1
+        col_no = node.start_point[1] + 1
+        error_type = 'Missing node' if node.is_missing else 'Syntax error'
+        errors.append((line_no, col_no, error_type))
+
+    for child in node.children:
+        errors += traverse_tree(child)
+
+    return errors
+
+
+class TreesitterBasicLinter(BaseLinter):
+    @property
+    def supported_extensions(self) -> list[str]:
+        return list(PARSERS.keys())
+
+    def lint(self, file_path: str) -> list[LintResult]:
+        """Use tree-sitter to look for syntax errors, display them with tree context."""
+        lang = filename_to_lang(file_path)
+        if not lang:
+            return []
+        parser = get_parser(lang)
+        with open(file_path, 'r') as f:
+            code = f.read()
+        tree = parser.parse(bytes(code, 'utf-8'))
+        errors = traverse_tree(tree.root_node)
+        if not errors:
+            return []
+        return [
+            LintResult(
+                file=file_path,
+                line=int(line),
+                column=int(col),
+                message=error_details,
+            )
+            for line, col, error_details in errors
+        ]

--- a/openhands_aci/linter/languages/python.py
+++ b/openhands_aci/linter/languages/python.py
@@ -1,0 +1,70 @@
+from openhands_aci.utils.logger import oh_aci_logger as logger
+from openhands_aci.utils.shell import run_shell_cmd
+
+from ..base import LintResult
+
+
+def python_compile_lint(fname: str) -> list[LintResult]:
+    try:
+        with open(fname, 'r') as f:
+            code = f.read()
+        compile(code, fname, 'exec')  # USE TRACEBACK BELOW HERE
+        return []
+    except SyntaxError as err:
+        err_lineno = getattr(err, 'end_lineno', err.lineno)
+        err_offset = getattr(err, 'end_offset', err.offset)
+        if err_offset and err_offset < 0:
+            err_offset = err.offset
+        return [
+            LintResult(
+                file=fname, line=err_lineno, column=err_offset or 1, message=err.msg
+            )
+        ]
+
+
+def flake_lint(filepath: str) -> list[LintResult]:
+    fatal = 'F821,F822,F831,E112,E113,E999,E902'
+    flake8_cmd = f'flake8 --select={fatal} --isolated {filepath}'
+
+    try:
+        cmd_outputs = run_shell_cmd(flake8_cmd, truncate_after=None)[1]
+    except FileNotFoundError:
+        return []
+    results: list[LintResult] = []
+    if not cmd_outputs:
+        return results
+    for line in cmd_outputs.splitlines():
+        parts = line.split(':')
+        if len(parts) >= 4:
+            _msg = parts[3].strip()
+            if len(parts) > 4:
+                _msg += ': ' + parts[4].strip()
+
+            try:
+                line_num = int(parts[1])
+            except ValueError as e:
+                logger.warning(
+                    f'Error parsing flake8 output for line: {e}. Parsed parts: {parts}. Skipping...'
+                )
+                continue
+
+            try:
+                column_num = int(parts[2])
+            except ValueError as e:
+                column_num = 1
+                _msg = (
+                    parts[2].strip() + ' ' + _msg
+                )  # add the unparsed message to the original message
+                logger.warning(
+                    f'Error parsing flake8 output for column: {e}. Parsed parts: {parts}. Using default column 1.'
+                )
+
+            results.append(
+                LintResult(
+                    file=filepath,
+                    line=line_num,
+                    column=column_num,
+                    message=_msg,
+                )
+            )
+    return results

--- a/openhands_aci/linter/linter.py
+++ b/openhands_aci/linter/linter.py
@@ -1,0 +1,122 @@
+import os
+from collections import defaultdict
+from difflib import SequenceMatcher
+
+from ..linter.base import BaseLinter, LinterException, LintResult
+from ..linter.impl.python import PythonLinter
+from ..linter.impl.treesitter import TreesitterBasicLinter
+
+
+class DefaultLinter(BaseLinter):
+    def __init__(self):
+        self.linters: dict[str, list[BaseLinter]] = defaultdict(list)
+        self.linters['.py'] = [PythonLinter()]
+
+        # Add treesitter linter as a fallback for all linters
+        self.basic_linter = TreesitterBasicLinter()
+        for extension in self.basic_linter.supported_extensions:
+            self.linters[extension].append(self.basic_linter)
+        self._supported_extensions = list(self.linters.keys())
+
+    @property
+    def supported_extensions(self) -> list[str]:
+        return self._supported_extensions
+
+    def lint(self, file_path: str) -> list[LintResult]:
+        if not os.path.isabs(file_path):
+            raise LinterException(f'File path {file_path} is not an absolute path')
+        file_extension = os.path.splitext(file_path)[1]
+
+        linters: list[BaseLinter] = self.linters.get(file_extension, [])
+        for linter in linters:
+            res = linter.lint(file_path)
+            # We always return the first linter's result (higher priority)
+            if res:
+                return res
+        return []
+
+    def lint_file_diff(
+        self, original_file_path: str, updated_file_path: str
+    ) -> list[LintResult]:
+        """Only return lint errors that are introduced by the diff.
+
+        Args:
+            original_file_path: The original file path.
+            updated_file_path: The updated file path.
+
+        Returns:
+            A list of lint errors that are introduced by the diff.
+        """
+        # 1. Lint the original and updated file
+        original_lint_errors: list[LintResult] = self.lint(original_file_path)
+        updated_lint_errors: list[LintResult] = self.lint(updated_file_path)
+
+        # 2. Load the original and updated file content
+        with open(original_file_path, 'r') as f:
+            old_lines = f.readlines()
+        with open(updated_file_path, 'r') as f:
+            new_lines = f.readlines()
+
+        # 3. Get line numbers that are changed & unchanged
+        # Map the line number of the original file to the updated file
+        # NOTE: this only works for lines that are not changed (i.e., equal)
+        old_to_new_line_no_mapping: dict[int, int] = {}
+        replace_or_inserted_lines: list[int] = []
+        for (
+            tag,
+            old_idx_start,
+            old_idx_end,
+            new_idx_start,
+            new_idx_end,
+        ) in SequenceMatcher(
+            isjunk=None,
+            a=old_lines,
+            b=new_lines,
+        ).get_opcodes():
+            if tag == 'equal':
+                for idx, _ in enumerate(old_lines[old_idx_start:old_idx_end]):
+                    old_to_new_line_no_mapping[old_idx_start + idx + 1] = (
+                        new_idx_start + idx + 1
+                    )
+            elif tag == 'replace' or tag == 'insert':
+                for idx, _ in enumerate(old_lines[old_idx_start:old_idx_end]):
+                    replace_or_inserted_lines.append(new_idx_start + idx + 1)
+            else:
+                # omit the case of delete
+                pass
+
+        # 4. Get pre-existing errors in unchanged lines
+        # increased error elsewhere introduced by the newlines
+        # i.e., we omit errors that are already in original files and report new one
+        new_line_no_to_original_errors: dict[int, list[LintResult]] = defaultdict(list)
+        for error in original_lint_errors:
+            if error.line in old_to_new_line_no_mapping:
+                new_line_no_to_original_errors[
+                    old_to_new_line_no_mapping[error.line]
+                ].append(error)
+
+        # 5. Select errors from lint results in new file to report
+        selected_errors = []
+        for error in updated_lint_errors:
+            # 5.1. Error introduced by replace/insert
+            if error.line in replace_or_inserted_lines:
+                selected_errors.append(error)
+            # 5.2. Error introduced by modified lines that impacted
+            #      the unchanged lines that HAVE pre-existing errors
+            elif error.line in new_line_no_to_original_errors:
+                # skip if the error is already reported
+                # or add if the error is new
+                if not any(
+                    original_error.message == error.message
+                    and original_error.column == error.column
+                    for original_error in new_line_no_to_original_errors[error.line]
+                ):
+                    selected_errors.append(error)
+            # 5.3. Error introduced by modified lines that impacted
+            #      the unchanged lines that have NO pre-existing errors
+            else:
+                selected_errors.append(error)
+
+        # 6. Sort errors by line and column
+        selected_errors.sort(key=lambda x: (x.line, x.column))
+        return selected_errors

--- a/openhands_aci/utils/diff.py
+++ b/openhands_aci/utils/diff.py
@@ -1,0 +1,41 @@
+import difflib
+
+import whatthepatch
+
+
+def get_diff(old_contents: str, new_contents: str, filepath: str = 'file') -> str:
+    diff = list(
+        difflib.unified_diff(
+            old_contents.split('\n'),
+            new_contents.split('\n'),
+            fromfile=filepath,
+            tofile=filepath,
+            # do not output unchange lines
+            # because they can cause `parse_diff` to fail
+            n=0,
+        )
+    )
+    return '\n'.join(map(lambda x: x.rstrip(), diff))
+
+
+def parse_diff(diff_patch: str) -> list[whatthepatch.patch.Change]:
+    # handle empty patch
+    if diff_patch.strip() == '':
+        return []
+
+    patch = whatthepatch.parse_patch(diff_patch)
+    patch_list = list(patch)
+    assert len(patch_list) == 1, (
+        'parse_diff only supports single file diff. But got:\nPATCH:\n'
+        + diff_patch
+        + '\nPATCH LIST:\n'
+        + str(patch_list)
+    )
+    changes = patch_list[0].changes
+
+    # ignore changes that are the same (i.e., old_lineno == new_lineno)
+    output_changes = []
+    for change in changes:
+        if change.old != change.new:
+            output_changes.append(change)
+    return output_changes

--- a/openhands_aci/utils/logger.py
+++ b/openhands_aci/utils/logger.py
@@ -1,0 +1,28 @@
+import logging
+import os
+
+LOG_LEVEL = os.getenv('LOG_LEVEL', 'INFO').upper()
+
+DEBUG = os.getenv('DEBUG', 'False').lower() in ['true', '1', 'yes']
+if DEBUG:
+    LOG_LEVEL = 'DEBUG'
+
+oh_aci_logger = logging.getLogger('openhands_aci')
+
+current_log_level = logging.INFO
+if LOG_LEVEL in logging.getLevelNamesMapping():
+    current_log_level = logging.getLevelNamesMapping()[LOG_LEVEL]
+
+console_handler = logging.StreamHandler()
+console_handler.setLevel(current_log_level)
+formatter = logging.Formatter(
+    '{asctime} - {name}:{levelname} - {message}',
+    style='{',
+    datefmt='%Y-%m-%d %H:%M',
+)
+console_handler.setFormatter(formatter)
+
+oh_aci_logger.setLevel(current_log_level)
+oh_aci_logger.addHandler(console_handler)
+oh_aci_logger.propagate = False
+oh_aci_logger.debug('Logger initialized')

--- a/openhands_aci/utils/shell.py
+++ b/openhands_aci/utils/shell.py
@@ -1,8 +1,8 @@
 import subprocess
 import time
 
-from .config import MAX_RESPONSE_LEN_CHAR
-from .results import maybe_truncate
+from ..editor.config import MAX_RESPONSE_LEN_CHAR
+from ..editor.results import maybe_truncate
 
 
 def run_shell_cmd(

--- a/openhands_aci/utils/shell.py
+++ b/openhands_aci/utils/shell.py
@@ -1,16 +1,27 @@
+import os
 import subprocess
 import time
 
-from ..editor.config import MAX_RESPONSE_LEN_CHAR
-from ..editor.results import maybe_truncate
+from openhands_aci.editor.config import MAX_RESPONSE_LEN_CHAR
+from openhands_aci.editor.results import maybe_truncate
 
 
 def run_shell_cmd(
     cmd: str,
     timeout: float | None = 120.0,  # seconds
     truncate_after: int | None = MAX_RESPONSE_LEN_CHAR,
-):
-    """Run a shell command synchronously with a timeout."""
+) -> tuple[int, str, str]:
+    """Run a shell command synchronously with a timeout.
+
+    Args:
+        cmd: The shell command to run.
+        timeout: The maximum time to wait for the command to complete.
+        truncate_after: The maximum number of characters to return for stdout and stderr.
+
+    Returns:
+        A tuple containing the return code, stdout, and stderr.
+    """
+
     start_time = time.time()
 
     try:
@@ -31,3 +42,18 @@ def run_shell_cmd(
         raise TimeoutError(
             f"Command '{cmd}' timed out after {elapsed_time:.2f} seconds"
         )
+
+
+def check_tool_installed(tool_name: str) -> bool:
+    """Check if a tool is installed."""
+    try:
+        subprocess.run(
+            [tool_name, '--version'],
+            check=True,
+            cwd=os.getcwd(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False

--- a/poetry.lock
+++ b/poetry.lock
@@ -397,6 +397,22 @@ testing = ["covdefaults (>=2.3)", "coverage (>=7.6.1)", "diff-cover (>=9.2)", "p
 typing = ["typing-extensions (>=4.12.2)"]
 
 [[package]]
+name = "flake8"
+version = "7.1.1"
+description = "the modular source code checker: pep8 pyflakes and co"
+optional = false
+python-versions = ">=3.8.1"
+files = [
+    {file = "flake8-7.1.1-py2.py3-none-any.whl", hash = "sha256:597477df7860daa5aa0fdd84bf5208a043ab96b8e96ab708770ae0364dd03213"},
+    {file = "flake8-7.1.1.tar.gz", hash = "sha256:049d058491e228e03e67b390f311bbf88fce2dbaa8fa673e7aea87b7198b8d38"},
+]
+
+[package.dependencies]
+mccabe = ">=0.7.0,<0.8.0"
+pycodestyle = ">=2.12.0,<2.13.0"
+pyflakes = ">=3.2.0,<3.3.0"
+
+[[package]]
 name = "frozenlist"
 version = "1.5.0"
 description = "A list-like structure which implements collections.abc.MutableSequence"
@@ -969,6 +985,17 @@ files = [
 ]
 
 [[package]]
+name = "mccabe"
+version = "0.7.0"
+description = "McCabe checker, plugin for flake8"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
+    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
+]
+
+[[package]]
 name = "multidict"
 version = "6.1.0"
 description = "multidict implementation"
@@ -1448,6 +1475,17 @@ files = [
 ]
 
 [[package]]
+name = "pycodestyle"
+version = "2.12.1"
+description = "Python style guide checker"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pycodestyle-2.12.1-py2.py3-none-any.whl", hash = "sha256:46f0fb92069a7c28ab7bb558f05bfc0110dac69a0cd23c61ea0040283a9d78b3"},
+    {file = "pycodestyle-2.12.1.tar.gz", hash = "sha256:6838eae08bbce4f6accd5d5572075c63626a15ee3e6f842df996bf62f6d73521"},
+]
+
+[[package]]
 name = "pydantic"
 version = "2.9.2"
 description = "Data validation using Python type hints"
@@ -1570,6 +1608,17 @@ files = [
 
 [package.dependencies]
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
+
+[[package]]
+name = "pyflakes"
+version = "3.2.0"
+description = "passive checker of Python programs"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pyflakes-3.2.0-py2.py3-none-any.whl", hash = "sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a"},
+    {file = "pyflakes-3.2.0.tar.gz", hash = "sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f"},
+]
 
 [[package]]
 name = "pytest"
@@ -2413,6 +2462,17 @@ docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "s
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8)", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10)"]
 
 [[package]]
+name = "whatthepatch"
+version = "1.0.6"
+description = "A patch parsing and application library."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "whatthepatch-1.0.6-py3-none-any.whl", hash = "sha256:c0cee5975e9b5cad8a0d12a52d76f8bb567ccdec319cf08c5fcfb1efab7fa1b2"},
+    {file = "whatthepatch-1.0.6.tar.gz", hash = "sha256:b274b3294784f78b1e759b35b49b7ef2e8473a580aabf39e5b94a9f901e5de61"},
+]
+
+[[package]]
 name = "yarl"
 version = "1.17.1"
 description = "Yet another URL library"
@@ -2530,4 +2590,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "e134342f8c51495b743769c44a0fd20589e8705480f113b8c650fb3cb34fecd7"
+content-hash = "0e7374c6ab359765af97ca2f296aa6bafcfc8cae8559dcbf420f635e55e7bc53"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ gitpython = "*"
 tree-sitter = "0.21.3"
 grep-ast = "0.3.3"
 diskcache = "^5.6.3"
+flake8 = "*"
+whatthepatch = "^1.0.6"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/integration/test_file_editor.py
+++ b/tests/integration/test_file_editor.py
@@ -18,15 +18,6 @@ def editor(tmp_path):
     return editor, test_file
 
 
-@pytest.fixture
-def editor_with_linting(tmp_path):
-    editor = OHEditor(enable_linting=True)
-    # Set up a temporary directory with test files
-    test_file = tmp_path / 'test.txt'
-    test_file.write_text('This is a test file.\nThis file is for testing purposes.')
-    return editor, test_file
-
-
 def test_view_file(editor):
     editor, test_file = editor
     result = editor(command='view', path=str(test_file))
@@ -77,13 +68,14 @@ Review the changes and make sure they are as expected. Edit the file again if ne
     assert 'This is a sample file.' in test_file.read_text()
 
 
-def test_str_replace_with_linting(editor_with_linting):
-    editor, test_file = editor_with_linting
+def test_str_replace_with_linting(editor):
+    editor, test_file = editor
     result = editor(
         command='str_replace',
         path=str(test_file),
         old_str='test file',
         new_str='sample file',
+        enable_linting=True,
     )
     assert isinstance(result, CLIResult)
 
@@ -144,10 +136,14 @@ Review the changes and make sure they are as expected (correct indentation, no d
     )
 
 
-def test_insert_with_linting(editor_with_linting):
-    editor, test_file = editor_with_linting
+def test_insert_with_linting(editor):
+    editor, test_file = editor
     result = editor(
-        command='insert', path=str(test_file), insert_line=1, new_str='Inserted line'
+        command='insert',
+        path=str(test_file),
+        insert_line=1,
+        new_str='Inserted line',
+        enable_linting=True,
     )
     assert isinstance(result, CLIResult)
     assert 'Inserted line' in test_file.read_text()

--- a/tests/integration/test_file_editor.py
+++ b/tests/integration/test_file_editor.py
@@ -54,8 +54,20 @@ def test_str_replace(editor):
         new_str='sample file',
     )
     assert isinstance(result, CLIResult)
-    assert 'The file' in result.output
-    assert 'sample file' in test_file.read_text()
+
+    # Test str_replace command
+    assert (
+        result.output
+        == f"""The file {test_file} has been edited. Here's the result of running `cat -n` on a snippet of {test_file}:
+     1\tThis is a sample file.
+     2\tThis file is for testing purposes.
+
+No linting issues found in the changes.
+Review the changes and make sure they are as expected. Edit the file again if necessary."""
+    )
+
+    # Test that the file content has been updated
+    assert 'This is a sample file.' in test_file.read_text()
 
 
 def test_str_replace_error_multiple_occurrences(editor):
@@ -89,6 +101,17 @@ def test_insert(editor):
     )
     assert isinstance(result, CLIResult)
     assert 'Inserted line' in test_file.read_text()
+    print(result.output)
+    assert (
+        result.output
+        == f"""The file {test_file} has been edited. Here's the result of running `cat -n` on a snippet of the edited file:
+     1\tThis is a test file.
+     2\tInserted line
+     3\tThis file is for testing purposes.
+
+No linting issues found in the changes.
+Review the changes and make sure they are as expected (correct indentation, no duplicate lines, etc). Edit the file again if necessary."""
+    )
 
 
 def test_insert_invalid_line(editor):

--- a/tests/integration/test_file_editor.py
+++ b/tests/integration/test_file_editor.py
@@ -115,10 +115,8 @@ def test_undo_edit(editor):
         old_str='test file',
         new_str='sample file',
     )
-    print(f'output: {result.output}')
     # Undo the edit
     result = editor(command='undo_edit', path=str(test_file))
-    print(result.output)
     assert isinstance(result, CLIResult)
     assert 'Last edit to' in result.output
     assert 'test file' in test_file.read_text()  # Original content restored

--- a/tests/unit/linter/conftest.py
+++ b/tests/unit/linter/conftest.py
@@ -1,0 +1,75 @@
+import pytest
+
+
+@pytest.fixture
+def syntax_error_py_file(tmp_path):
+    file_content = """
+    def foo():
+        print("Hello, World!")
+    print("Wrong indent")
+    foo(
+    """
+    file_path = tmp_path / 'test_file.py'
+    file_path.write_text(file_content)
+    return str(file_path)
+
+
+@pytest.fixture
+def wrongly_indented_py_file(tmp_path):
+    file_content = """
+    def foo():
+            print("Hello, World!")
+    """
+    file_path = tmp_path / 'test_file.py'
+    file_path.write_text(file_content)
+    return str(file_path)
+
+
+@pytest.fixture
+def simple_correct_py_file(tmp_path):
+    file_content = 'print("Hello, World!")\n'
+    file_path = tmp_path / 'test_file.py'
+    file_path.write_text(file_content)
+    return str(file_path)
+
+
+@pytest.fixture
+def simple_correct_py_func_def(tmp_path):
+    file_content = """def foo():
+    print("Hello, World!")
+foo()
+"""
+    file_path = tmp_path / 'test_file.py'
+    file_path.write_text(file_content)
+    return str(file_path)
+
+
+@pytest.fixture
+def simple_correct_ruby_file(tmp_path):
+    file_content = """def foo
+  puts "Hello, World!"
+end
+foo
+"""
+    file_path = tmp_path / 'test_file.rb'
+    file_path.write_text(file_content)
+    return str(file_path)
+
+
+@pytest.fixture
+def simple_incorrect_ruby_file(tmp_path):
+    file_content = """def foo():
+    print("Hello, World!")
+foo()
+"""
+    file_path = tmp_path / 'test_file.rb'
+    file_path.write_text(file_content)
+    return str(file_path)
+
+
+@pytest.fixture
+def parenthesis_incorrect_ruby_file(tmp_path):
+    file_content = """def print_hello_world()\n    puts 'Hello World'\n"""
+    file_path = tmp_path / 'test_file.rb'
+    file_path.write_text(file_content)
+    return str(file_path)

--- a/tests/unit/linter/test_lint_diff.py
+++ b/tests/unit/linter/test_lint_diff.py
@@ -1,0 +1,417 @@
+from openhands_aci.linter import DefaultLinter, LintResult
+from openhands_aci.utils.diff import get_diff, parse_diff
+
+OLD_CONTENT = """
+def foo():
+    print("Hello, World!")
+    x = UNDEFINED_VARIABLE
+foo()
+"""
+
+NEW_CONTENT_V1 = (
+    OLD_CONTENT
+    + """
+def new_function_that_causes_error():
+    y = ANOTHER_UNDEFINED_VARIABLE
+"""
+)
+
+NEW_CONTENT_V2 = """
+def foo():
+    print("Hello, World!")
+    x = UNDEFINED_VARIABLE
+    y = ANOTHER_UNDEFINED_VARIABLE
+foo()
+"""
+
+
+def test_get_and_parse_diff(tmp_path):
+    diff = get_diff(OLD_CONTENT, NEW_CONTENT_V1, 'test.py')
+    print(diff)
+    assert (
+        diff
+        == """
+--- test.py
++++ test.py
+@@ -6,0 +7,3 @@
++def new_function_that_causes_error():
++    y = ANOTHER_UNDEFINED_VARIABLE
++
+""".strip()
+    )
+
+    print(
+        '\n'.join(
+            [f'{i+1}|{line}' for i, line in enumerate(NEW_CONTENT_V1.splitlines())]
+        )
+    )
+    changes = parse_diff(diff)
+    assert len(changes) == 3
+    assert (
+        changes[0].old is None
+        and changes[0].new == 7
+        and changes[0].line == 'def new_function_that_causes_error():'
+    )
+    assert (
+        changes[1].old is None
+        and changes[1].new == 8
+        and changes[1].line == '    y = ANOTHER_UNDEFINED_VARIABLE'
+    )
+    assert changes[2].old is None and changes[2].new == 9 and changes[2].line == ''
+
+
+def test_lint_with_diff_append(tmp_path):
+    with open(tmp_path / 'old.py', 'w') as f:
+        f.write(OLD_CONTENT)
+    with open(tmp_path / 'new.py', 'w') as f:
+        f.write(NEW_CONTENT_V1)
+
+    linter = DefaultLinter()
+    result: list[LintResult] = linter.lint_file_diff(
+        str(tmp_path / 'old.py'),
+        str(tmp_path / 'new.py'),
+    )
+    print(result)
+    assert len(result) == 1
+    assert (
+        result[0].line == 8
+        and result[0].column == 9
+        and result[0].message == "F821 undefined name 'ANOTHER_UNDEFINED_VARIABLE'"
+    )
+
+
+def test_lint_with_diff_insert(tmp_path):
+    with open(tmp_path / 'old.py', 'w') as f:
+        f.write(OLD_CONTENT)
+    with open(tmp_path / 'new.py', 'w') as f:
+        f.write(NEW_CONTENT_V2)
+
+    linter = DefaultLinter()
+    result: list[LintResult] = linter.lint_file_diff(
+        str(tmp_path / 'old.py'),
+        str(tmp_path / 'new.py'),
+    )
+    assert len(result) == 1
+    assert (
+        result[0].line == 5
+        and result[0].column == 9
+        and result[0].message == "F821 undefined name 'ANOTHER_UNDEFINED_VARIABLE'"
+    )
+
+
+def test_lint_with_multiple_changes_and_errors(tmp_path):
+    old_content = """
+def foo():
+    print("Hello, World!")
+    x = 10
+foo()
+"""
+    new_content = """
+def foo():
+    print("Hello, World!")
+    x = UNDEFINED_VARIABLE
+    y = 20
+
+def bar():
+    z = ANOTHER_UNDEFINED_VARIABLE
+    return z + 1
+
+foo()
+bar()
+"""
+    with open(tmp_path / 'old.py', 'w') as f:
+        f.write(old_content)
+    with open(tmp_path / 'new.py', 'w') as f:
+        f.write(new_content)
+
+    linter = DefaultLinter()
+    result: list[LintResult] = linter.lint_file_diff(
+        str(tmp_path / 'old.py'),
+        str(tmp_path / 'new.py'),
+    )
+    assert len(result) == 2
+    assert (
+        result[0].line == 4
+        and result[0].column == 9
+        and result[0].message == "F821 undefined name 'UNDEFINED_VARIABLE'"
+    )
+    assert (
+        result[1].line == 8
+        and result[1].column == 9
+        and result[1].message == "F821 undefined name 'ANOTHER_UNDEFINED_VARIABLE'"
+    )
+
+
+def test_lint_with_introduced_and_fixed_errors(tmp_path):
+    old_content = """
+x = UNDEFINED_VARIABLE
+y = 10
+"""
+    new_content = """
+x = 5
+y = ANOTHER_UNDEFINED_VARIABLE
+z = UNDEFINED_VARIABLE
+"""
+    with open(tmp_path / 'old.py', 'w') as f:
+        f.write(old_content)
+    with open(tmp_path / 'new.py', 'w') as f:
+        f.write(new_content)
+
+    linter = DefaultLinter()
+    result: list[LintResult] = linter.lint_file_diff(
+        str(tmp_path / 'old.py'),
+        str(tmp_path / 'new.py'),
+    )
+    assert len(result) == 2
+    assert (
+        result[0].line == 3
+        and result[0].column == 5
+        and result[0].message == "F821 undefined name 'ANOTHER_UNDEFINED_VARIABLE'"
+    )
+    assert (
+        result[1].line == 4
+        and result[1].column == 5
+        and result[1].message == "F821 undefined name 'UNDEFINED_VARIABLE'"
+    )
+
+
+def test_lint_with_multiline_changes(tmp_path):
+    old_content = """
+def complex_function(a, b, c):
+    return (a +
+            b +
+            c)
+"""
+    new_content = """
+def complex_function(a, b, c):
+    return (a +
+            UNDEFINED_VARIABLE +
+            b +
+            c)
+"""
+    with open(tmp_path / 'old.py', 'w') as f:
+        f.write(old_content)
+    with open(tmp_path / 'new.py', 'w') as f:
+        f.write(new_content)
+
+    linter = DefaultLinter()
+    result: list[LintResult] = linter.lint_file_diff(
+        str(tmp_path / 'old.py'),
+        str(tmp_path / 'new.py'),
+    )
+    assert len(result) == 1
+    assert (
+        result[0].line == 4
+        and result[0].column == 13
+        and result[0].message == "F821 undefined name 'UNDEFINED_VARIABLE'"
+    )
+
+
+def test_lint_with_syntax_error(tmp_path):
+    old_content = """
+def foo():
+    print("Hello, World!")
+"""
+    new_content = """
+def foo():
+    print("Hello, World!"
+"""
+    with open(tmp_path / 'old.py', 'w') as f:
+        f.write(old_content)
+    with open(tmp_path / 'new.py', 'w') as f:
+        f.write(new_content)
+
+    linter = DefaultLinter()
+    result: list[LintResult] = linter.lint_file_diff(
+        str(tmp_path / 'old.py'),
+        str(tmp_path / 'new.py'),
+    )
+    assert len(result) == 1
+    assert (
+        result[0].line == 3
+        and result[0].column == 11
+        and result[0].message == "E999 SyntaxError: '(' was never closed"
+    )
+
+
+def test_lint_with_docstring_changes(tmp_path):
+    old_content = '''
+def foo():
+    """This is a function."""
+    print("Hello, World!")
+'''
+    new_content = '''
+def foo():
+    """
+    This is a function.
+    It now has a multi-line docstring with an UNDEFINED_VARIABLE.
+    """
+    print("Hello, World!")
+'''
+    with open(tmp_path / 'old.py', 'w') as f:
+        f.write(old_content)
+    with open(tmp_path / 'new.py', 'w') as f:
+        f.write(new_content)
+
+    linter = DefaultLinter()
+    result: list[LintResult] = linter.lint_file_diff(
+        str(tmp_path / 'old.py'),
+        str(tmp_path / 'new.py'),
+    )
+    assert len(result) == 0  # Linter should ignore changes in docstrings
+
+
+def test_lint_with_multiple_errors_on_same_line(tmp_path):
+    old_content = """
+def foo():
+    print("Hello, World!")
+    x = 10
+foo()
+"""
+    new_content = """
+def foo():
+    print("Hello, World!")
+    x = UNDEFINED_VARIABLE + ANOTHER_UNDEFINED_VARIABLE
+foo()
+"""
+    with open(tmp_path / 'old.py', 'w') as f:
+        f.write(old_content)
+    with open(tmp_path / 'new.py', 'w') as f:
+        f.write(new_content)
+
+    linter = DefaultLinter()
+    result: list[LintResult] = linter.lint_file_diff(
+        str(tmp_path / 'old.py'),
+        str(tmp_path / 'new.py'),
+    )
+    print(result)
+    assert len(result) == 2
+    assert (
+        result[0].line == 4
+        and result[0].column == 9
+        and result[0].message == "F821 undefined name 'UNDEFINED_VARIABLE'"
+    )
+    assert (
+        result[1].line == 4
+        and result[1].column == 30
+        and result[1].message == "F821 undefined name 'ANOTHER_UNDEFINED_VARIABLE'"
+    )
+
+
+def test_parse_diff_with_empty_patch():
+    diff_patch = ''
+    changes = parse_diff(diff_patch)
+    assert len(changes) == 0
+
+
+def test_lint_file_diff_ignore_existing_errors(tmp_path):
+    """
+    Make sure we allow edits as long as it does not introduce new errors. In other
+    words, we don't care about existing linting errors. Although they might be
+    real syntax issues, sometimes they are just false positives, or errors that
+    we don't care about.
+    """
+    content = """def some_valid_but_weird_function():
+    # this function is legitimate, yet static analysis tools like flake8
+    # reports 'F821 undefined name'
+    if 'variable' in locals():
+        print(variable)
+def some_wrong_but_unused_function():
+    # this function has a linting error, but it is not modified by us, and
+    # who knows, this function might be completely dead code
+    x = 1
+def sum(a, b):
+    return a - b
+"""
+    new_content = content.replace('    return a - b', '    return a + b')
+    temp_file_old_path = tmp_path / 'problematic-file-test.py'
+    temp_file_old_path.write_text(content)
+    temp_file_new_path = tmp_path / 'problematic-file-test-new.py'
+    temp_file_new_path.write_text(new_content)
+
+    linter = DefaultLinter()
+    result: list[LintResult] = linter.lint_file_diff(
+        str(temp_file_old_path),
+        str(temp_file_new_path),
+    )
+    assert len(result) == 0  # no new errors introduced
+
+
+def test_lint_file_diff_catch_new_errors_in_edits(tmp_path):
+    """
+    Make sure we catch new linting errors in our edit chunk, and at the same
+    time, ignore old linting errors (in this case, the old linting error is
+    a false positive)
+    """
+    content = """def some_valid_but_weird_function():
+    # this function is legitimate, yet static analysis tools like flake8
+    # reports 'F821 undefined name'
+    if 'variable' in locals():
+        print(variable)
+def sum(a, b):
+    return a - b
+"""
+
+    temp_file_old_path = tmp_path / 'problematic-file-test.py'
+    temp_file_old_path.write_text(content)
+    new_content = content.replace('    return a - b', '    return a + variable')
+    temp_file_new_path = tmp_path / 'problematic-file-test-new.py'
+    temp_file_new_path.write_text(new_content)
+
+    linter = DefaultLinter()
+    result: list[LintResult] = linter.lint_file_diff(
+        str(temp_file_old_path),
+        str(temp_file_new_path),
+    )
+    print(result)
+    assert len(result) == 1
+    assert (
+        result[0].line == 7
+        and result[0].column == 16
+        and result[0].message == "F821 undefined name 'variable'"
+    )
+
+
+def test_lint_file_diff_catch_new_errors_outside_edits(tmp_path):
+    """
+    Make sure we catch new linting errors induced by our edits, even
+    though the error itself is not in the edit chunk
+    """
+    content = """def valid_func1():
+    print(my_sum(1, 2))
+def my_sum(a, b):
+    return a - b
+def valid_func2():
+    print(my_sum(0, 0))
+"""
+    # Add 100 lines of invalid code, which linter shall ignore
+    # because they are not being edited. For testing purpose, we
+    # must add these existing linting errors, otherwise the pre-edit
+    # linting would pass, and thus there won't be any comparison
+    # between pre-edit and post-edit linting.
+    for _ in range(100):
+        content += '\ninvalid_func()'
+
+    temp_file_old_path = tmp_path / 'problematic-file-test.py'
+    temp_file_old_path.write_text(content)
+
+    new_content = content.replace('def my_sum(a, b):', 'def my_sum2(a, b):')
+    temp_file_new_path = tmp_path / 'problematic-file-test-new.py'
+    temp_file_new_path.write_text(new_content)
+
+    linter = DefaultLinter()
+    result: list[LintResult] = linter.lint_file_diff(
+        str(temp_file_old_path),
+        str(temp_file_new_path),
+    )
+    assert len(result) == 2
+    assert (
+        result[0].line == 2
+        and result[0].column == 11
+        and result[0].message == "F821 undefined name 'my_sum'"
+    )
+    assert (
+        result[1].line == 6
+        and result[1].column == 11
+        and result[1].message == "F821 undefined name 'my_sum'"
+    )

--- a/tests/unit/linter/test_python_linter.py
+++ b/tests/unit/linter/test_python_linter.py
@@ -1,0 +1,84 @@
+from openhands_aci.linter import DefaultLinter, LintResult
+from openhands_aci.linter.impl.python import (
+    PythonLinter,
+    flake_lint,
+    python_compile_lint,
+)
+
+
+def test_wrongly_indented_py_file(wrongly_indented_py_file):
+    # Test Python linter
+    linter = PythonLinter()
+    assert '.py' in linter.supported_extensions
+    result = linter.lint(wrongly_indented_py_file)
+    print(result)
+    assert isinstance(result, list) and len(result) == 1
+    assert result[0] == LintResult(
+        file=wrongly_indented_py_file,
+        line=2,
+        column=5,
+        message='E999 IndentationError: unexpected indent',
+    )
+    print(result[0].visualize())
+    assert result[0].visualize() == (
+        '1|\n'
+        '\033[91m2|    def foo():\033[0m\n'
+        '      ^ ERROR HERE: E999 IndentationError: unexpected indent\n'
+        '3|            print("Hello, World!")\n'
+        '4|'
+    )
+
+    # General linter should have same result as Python linter
+    # bc it uses PythonLinter under the hood
+    general_linter = DefaultLinter()
+    assert '.py' in general_linter.supported_extensions
+    result = general_linter.lint(wrongly_indented_py_file)
+    assert result == linter.lint(wrongly_indented_py_file)
+
+    # Test flake8_lint
+    assert result == flake_lint(wrongly_indented_py_file)
+
+    # Test python_compile_lint
+    compile_result = python_compile_lint(wrongly_indented_py_file)
+    assert isinstance(compile_result, list) and len(compile_result) == 1
+    assert compile_result[0] == LintResult(
+        file=wrongly_indented_py_file, line=2, column=4, message='unexpected indent'
+    )
+
+
+def test_simple_correct_py_file(simple_correct_py_file):
+    linter = PythonLinter()
+    assert '.py' in linter.supported_extensions
+    result = linter.lint(simple_correct_py_file)
+    assert result == []
+
+    general_linter = DefaultLinter()
+    assert '.py' in general_linter.supported_extensions
+    result = general_linter.lint(simple_correct_py_file)
+    assert result == linter.lint(simple_correct_py_file)
+
+    # Test python_compile_lint
+    compile_result = python_compile_lint(simple_correct_py_file)
+    assert compile_result == []
+
+    # Test flake_lint
+    flake_result = flake_lint(simple_correct_py_file)
+    assert flake_result == []
+
+
+def test_simple_correct_py_func_def(simple_correct_py_func_def):
+    linter = PythonLinter()
+    result = linter.lint(simple_correct_py_func_def)
+    assert result == []
+
+    general_linter = DefaultLinter()
+    assert '.py' in general_linter.supported_extensions
+    result = general_linter.lint(simple_correct_py_func_def)
+    assert result == linter.lint(simple_correct_py_func_def)
+
+    # Test flake_lint
+    assert result == flake_lint(simple_correct_py_func_def)
+
+    # Test python_compile_lint
+    compile_result = python_compile_lint(simple_correct_py_func_def)
+    assert compile_result == []

--- a/tests/unit/linter/test_treesitter_linter.py
+++ b/tests/unit/linter/test_treesitter_linter.py
@@ -1,0 +1,113 @@
+from openhands_aci.linter import DefaultLinter, LintResult
+from openhands_aci.linter.impl.treesitter import TreesitterBasicLinter
+
+
+def test_syntax_error_py_file(syntax_error_py_file):
+    linter = TreesitterBasicLinter()
+    result = linter.lint(syntax_error_py_file)
+    print(result)
+    assert isinstance(result, list) and len(result) == 1
+    assert result[0] == LintResult(
+        file=syntax_error_py_file,
+        line=5,
+        column=5,
+        message='Syntax error',
+    )
+
+    assert (
+        result[0].visualize()
+        == (
+            '2|    def foo():\n'
+            '3|        print("Hello, World!")\n'
+            '4|    print("Wrong indent")\n'
+            '\033[91m5|    foo(\033[0m\n'  # color red
+            '      ^ ERROR HERE: Syntax error\n'
+            '6|'
+        )
+    )
+    print(result[0].visualize())
+
+    general_linter = DefaultLinter()
+    general_result = general_linter.lint(syntax_error_py_file)
+    # NOTE: general linter returns different result
+    # because it uses flake8 first, which is different from treesitter
+    assert general_result != result
+
+
+def test_simple_correct_ruby_file(simple_correct_ruby_file):
+    linter = TreesitterBasicLinter()
+    result = linter.lint(simple_correct_ruby_file)
+    assert isinstance(result, list) and len(result) == 0
+
+    # Test that the general linter also returns the same result
+    general_linter = DefaultLinter()
+    general_result = general_linter.lint(simple_correct_ruby_file)
+    assert general_result == result
+
+
+def test_simple_incorrect_ruby_file(simple_incorrect_ruby_file):
+    linter = TreesitterBasicLinter()
+    result = linter.lint(simple_incorrect_ruby_file)
+    print(result)
+    assert isinstance(result, list) and len(result) == 2
+    assert result[0] == LintResult(
+        file=simple_incorrect_ruby_file,
+        line=1,
+        column=1,
+        message='Syntax error',
+    )
+    print(result[0].visualize())
+    assert (
+        result[0].visualize()
+        == (
+            '\033[91m1|def foo():\033[0m\n'  # color red
+            '  ^ ERROR HERE: Syntax error\n'
+            '2|    print("Hello, World!")\n'
+            '3|foo()'
+        )
+    )
+    assert result[1] == LintResult(
+        file=simple_incorrect_ruby_file,
+        line=1,
+        column=10,
+        message='Syntax error',
+    )
+    print(result[1].visualize())
+    assert (
+        result[1].visualize()
+        == (
+            '\033[91m1|def foo():\033[0m\n'  # color red
+            '           ^ ERROR HERE: Syntax error\n'
+            '2|    print("Hello, World!")\n'
+            '3|foo()'
+        )
+    )
+
+    # Test that the general linter also returns the same result
+    general_linter = DefaultLinter()
+    general_result = general_linter.lint(simple_incorrect_ruby_file)
+    assert general_result == result
+
+
+def test_parenthesis_incorrect_ruby_file(parenthesis_incorrect_ruby_file):
+    linter = TreesitterBasicLinter()
+    result = linter.lint(parenthesis_incorrect_ruby_file)
+    print(result)
+    assert isinstance(result, list) and len(result) == 1
+    assert result[0] == LintResult(
+        file=parenthesis_incorrect_ruby_file,
+        line=1,
+        column=1,
+        message='Syntax error',
+    )
+    print(result[0].visualize())
+    assert result[0].visualize() == (
+        '\033[91m1|def print_hello_world()\033[0m\n'
+        '  ^ ERROR HERE: Syntax error\n'
+        "2|    puts 'Hello World'"
+    )
+
+    # Test that the general linter also returns the same result
+    general_linter = DefaultLinter()
+    general_result = general_linter.lint(parenthesis_incorrect_ruby_file)
+    assert general_result == result

--- a/tests/unit/linter/test_visualize.py
+++ b/tests/unit/linter/test_visualize.py
@@ -1,0 +1,86 @@
+from unittest.mock import mock_open, patch
+
+import pytest
+
+from openhands_aci.linter.base import LintResult
+
+
+@pytest.fixture
+def mock_file_content():
+    return '\n'.join([f'Line {i}' for i in range(1, 21)])
+
+
+def test_visualize_standard_case(mock_file_content):
+    lint_result = LintResult(
+        file='test_file.py', line=10, column=5, message='Test error message'
+    )
+
+    with patch('builtins.open', mock_open(read_data=mock_file_content)):
+        result = lint_result.visualize(half_window=3)
+
+    expected_output = (
+        " 7|Line 7\n"
+        " 8|Line 8\n"
+        " 9|Line 9\n"
+        "\033[91m10|Line 10\033[0m\n"
+        f"  {' ' * lint_result.column}^ ERROR HERE: Test error message\n"
+        "11|Line 11\n"
+        "12|Line 12\n"
+        "13|Line 13"
+    )
+
+    assert result == expected_output
+
+
+def test_visualize_small_window(mock_file_content):
+    lint_result = LintResult(
+        file='test_file.py', line=10, column=5, message='Test error message'
+    )
+
+    with patch('builtins.open', mock_open(read_data=mock_file_content)):
+        result = lint_result.visualize(half_window=1)
+
+    expected_output = (
+        " 9|Line 9\n"
+        "\033[91m10|Line 10\033[0m\n"
+        f"  {' ' * lint_result.column}^ ERROR HERE: Test error message\n"
+        "11|Line 11"
+    )
+
+    assert result == expected_output
+
+
+def test_visualize_error_at_start(mock_file_content):
+    lint_result = LintResult(
+        file='test_file.py', line=1, column=3, message='Start error'
+    )
+
+    with patch('builtins.open', mock_open(read_data=mock_file_content)):
+        result = lint_result.visualize(half_window=2)
+
+    expected_output = (
+        "\033[91m 1|Line 1\033[0m\n"
+        f"  {' ' * lint_result.column}^ ERROR HERE: Start error\n"
+        " 2|Line 2\n"
+        " 3|Line 3"
+    )
+
+    assert result == expected_output
+
+
+def test_visualize_error_at_end(mock_file_content):
+    lint_result = LintResult(
+        file='test_file.py', line=20, column=1, message='End error'
+    )
+
+    with patch('builtins.open', mock_open(read_data=mock_file_content)):
+        result = lint_result.visualize(half_window=2)
+
+    expected_output = (
+        "18|Line 18\n"
+        "19|Line 19\n"
+        "\033[91m20|Line 20\033[0m\n"
+        f"  {' ' * lint_result.column}^ ERROR HERE: End error"
+    )
+
+    assert result == expected_output

--- a/tests/unit/test_shell_utils.py
+++ b/tests/unit/test_shell_utils.py
@@ -5,7 +5,7 @@ import pytest
 
 from openhands_aci.editor.config import MAX_RESPONSE_LEN_CHAR
 from openhands_aci.editor.prompts import CONTENT_TRUNCATED_NOTICE
-from openhands_aci.editor.shell import run_shell_cmd
+from openhands_aci.utils.shell import run_shell_cmd
 
 
 def test_run_shell_cmd_success():

--- a/tests/unit/test_shell_utils.py
+++ b/tests/unit/test_shell_utils.py
@@ -5,7 +5,7 @@ import pytest
 
 from openhands_aci.editor.config import MAX_RESPONSE_LEN_CHAR
 from openhands_aci.editor.prompts import CONTENT_TRUNCATED_NOTICE
-from openhands_aci.utils.shell import run_shell_cmd
+from openhands_aci.utils.shell import check_tool_installed, run_shell_cmd
 
 
 def test_run_shell_cmd_success():
@@ -45,3 +45,15 @@ def test_run_shell_cmd_truncation(mock_popen):
     assert returncode == 0
     assert len(stdout) <= MAX_RESPONSE_LEN_CHAR + len(CONTENT_TRUNCATED_NOTICE)
     assert len(stderr) <= MAX_RESPONSE_LEN_CHAR + len(CONTENT_TRUNCATED_NOTICE)
+
+
+def test_check_tool_installed_whoami():
+    """Test check_tool_installed returns True for an installed tool (whoami)."""
+    # 'python' is usually available if Python is installed
+    assert check_tool_installed('whoami') is True
+
+
+def test_check_tool_installed_nonexistent_tool():
+    """Test check_tool_installed returns False for a nonexistent tool."""
+    # Use a made-up tool name that is very unlikely to exist
+    assert check_tool_installed('nonexistent_tool_xyz') is False


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR is to:
- [x] Port the existing linter from `OpenHands` into `openhands-aci`
- [x] Add logging
- [x] Add ability to run linter after `str_replace` and `insert` command in the editor. This can be toggled on as below (IMO this is not very easy to use yet and can be improved):

```python
from openhands_aci import file_editor as _file_editor

def file_editor(*args, **kwargs):
    # Override enable_linting to True by default
    kwargs['enable_linting'] = True
    return _file_editor(*args, **kwargs)
```

## Related Issue
Fixes #7 