### PR TITLE
fix: raise error when `new_str` and `old_str` are the same

### DIFF
--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -73,7 +73,7 @@ class OHEditor:
                 raise EditorToolParameterInvalidError(
                     'new_str',
                     new_str,
-                    '`new_str` and `old_str` must be different.',
+                    'No replacement was performed. `new_str` and `old_str` must be different.',
                 )
             return self.str_replace(_path, old_str, new_str, enable_linting)
         elif command == 'insert':

--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -69,6 +69,12 @@ class OHEditor:
         elif command == 'str_replace':
             if not old_str:
                 raise EditorToolParameterMissingError(command, 'old_str')
+            if new_str == old_str:
+                raise EditorToolParameterInvalidError(
+                    'new_str',
+                    new_str,
+                    '`new_str` and `old_str` must be different.',
+                )
             return self.str_replace(_path, old_str, new_str, enable_linting)
         elif command == 'insert':
             if insert_line is None:

--- a/tests/integration/test_file_editor.py
+++ b/tests/integration/test_file_editor.py
@@ -219,7 +219,10 @@ def test_str_replace_new_str_and_old_str_same(editor):
             old_str='test file',
             new_str='test file',
         )
-    assert 'No replacement was performed. `new_str` and `old_str` must be different.' in str(exc_info.value.message)
+    assert (
+        'No replacement was performed. `new_str` and `old_str` must be different.'
+        in str(exc_info.value.message)
+    )
 
 
 def test_insert_missing_line_param(editor):

--- a/tests/integration/test_file_editor.py
+++ b/tests/integration/test_file_editor.py
@@ -219,7 +219,7 @@ def test_str_replace_new_str_and_old_str_same(editor):
             old_str='test file',
             new_str='test file',
         )
-    assert '`new_str` and `old_str` must be different.' in str(exc_info.value.message)
+    assert 'No replacement was performed. `new_str` and `old_str` must be different.' in str(exc_info.value.message)
 
 
 def test_insert_missing_line_param(editor):

--- a/tests/integration/test_file_editor.py
+++ b/tests/integration/test_file_editor.py
@@ -210,6 +210,18 @@ def test_str_replace_missing_old_str(editor):
         editor(command='str_replace', path=str(test_file), new_str='sample')
 
 
+def test_str_replace_new_str_and_old_str_same(editor):
+    editor, test_file = editor
+    with pytest.raises(EditorToolParameterInvalidError) as exc_info:
+        editor(
+            command='str_replace',
+            path=str(test_file),
+            old_str='test file',
+            new_str='test file',
+        )
+    assert '`new_str` and `old_str` must be different.' in str(exc_info.value.message)
+
+
 def test_insert_missing_line_param(editor):
     editor, test_file = editor
     with pytest.raises(EditorToolParameterMissingError):


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This PR is to:
- Raise error when the agent calls `str_replace` command with `new_str` and `old_str` having the same value. The misleading "file updated successfully" message may potentially confuse the agent and make it stuck in the loop.

