### PR TITLE
fix: missing `expandtabs` call in `str_replace` command

### DIFF
--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -95,7 +95,7 @@ class OHEditor:
         """
         Implement the str_replace command, which replaces old_str with new_str in the file content.
         """
-        file_content = self.read_file(path)
+        file_content = self.read_file(path).expandtabs()
         old_str = old_str.expandtabs()
         new_str = new_str.expandtabs() if new_str is not None else ''
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

~~The current `str_replace` method doesn't call `expandtabs` after `self.read_file()`, which cause the `old_str` to be not found (count == 0) when it contains tab character. `old_str.expandtabs()` will expand to 8 spaces by default.~~ -- I looked into the trajectory again and seems like it's an issue from the LLM, not from the tool execution. But the current implementation indeed missing a `expandtabs` call compared to original implementation. I may need your help to double check if my observation from the trajectory is correct though.

- Current implementation: https://github.com/All-Hands-AI/openhands-aci/blob/8062562e30a46df7eeac202eaa8ad6b14a479771/openhands_aci/editor/editor.py#L98
- Original implementation: https://github.com/anthropics/anthropic-quickstarts/blob/eabba4bcef76d1366f9b172263716aaac174f441/computer-use-demo/computer_use_demo/tools/edit.py#L159

## Related Issue
<!--- Use the keywords 'Close', 'Closes', 'Fix', or 'Fixes' followed by the issue number(s) to close the related issue(s) -->

https://openhands-ai.slack.com/archives/C06U8UTKSAD/p1732250327646839


