### PR TITLE
Add navigation suggestion and file skeleton for `view` command

### DIFF
--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -189,18 +189,21 @@ class OHEditor:
             _, stdout, stderr = run_shell_cmd(
                 rf"find {path} -maxdepth 2 -not -path '*/\.*'"
             )
-            all_abs_paths_list = stdout.split('\n')
-            abs_path_to_skeleton = self._symbol_navigator.get_skeletons(
-                all_abs_paths_list
-            )
-            stdout = '\n'.join(
-                [
-                    f'{abs_path}{'\n' + abs_path_to_skeleton[abs_path] if abs_path in abs_path_to_skeleton else ''}'
-                    for abs_path in all_abs_paths_list
-                ]
-            )
             if not stderr:
-                stdout = f"Here's the files and directories up to 2 levels deep in {path}, excluding hidden items:\n{stdout}\n"
+                if self._symbol_navigator.is_enabled:
+                    all_abs_paths_list = stdout.split('\n')
+                    abs_path_to_skeleton = self._symbol_navigator.get_skeletons(
+                        all_abs_paths_list
+                    )
+                    stdout = '\n'.join(
+                        [
+                            f'{abs_path}{'\n' + abs_path_to_skeleton[abs_path] if abs_path in abs_path_to_skeleton else ''}'
+                            for abs_path in all_abs_paths_list
+                        ]
+                    )
+                    stdout = f"Here's the files with its skeleton (i.e., class, function/method signatures) and directories up to 2 levels deep in {path}, excluding hidden items:\n{stdout}\n"
+                else:
+                    stdout = f"Here's the files and directories up to 2 levels deep in {path}, excluding hidden items:\n{stdout}\n"
             return CLIResult(output=stdout, error=stderr)
 
         file_content = self.read_file(path)

--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -189,6 +189,16 @@ class OHEditor:
             _, stdout, stderr = run_shell_cmd(
                 rf"find {path} -maxdepth 2 -not -path '*/\.*'"
             )
+            all_abs_paths_list = stdout.split('\n')
+            abs_path_to_skeleton = self._symbol_navigator.get_skeletons(
+                all_abs_paths_list
+            )
+            stdout = '\n'.join(
+                [
+                    f'{abs_path}{'\n' + abs_path_to_skeleton[abs_path] if abs_path in abs_path_to_skeleton else ''}'
+                    for abs_path in all_abs_paths_list
+                ]
+            )
             if not stderr:
                 stdout = f"Here's the files and directories up to 2 levels deep in {path}, excluding hidden items:\n{stdout}\n"
             return CLIResult(output=stdout, error=stderr)

--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -166,12 +166,6 @@ class OHEditor:
             success_message += '\n' + lint_results + '\n'
 
         success_message += 'Review the changes and make sure they are as expected. Edit the file again if necessary.'
-        success_message += (
-            self._symbol_navigator.get_out_and_in_edges_suggestion(str(path))
-            + f'{NAVIGATION_TIPS}'
-            if self._symbol_navigator.is_enabled
-            else ''
-        )
         return CLIResult(
             output=success_message,
             prev_exist=True,
@@ -323,12 +317,6 @@ class OHEditor:
             success_message += '\n' + lint_results + '\n'
 
         success_message += 'Review the changes and make sure they are as expected (correct indentation, no duplicate lines, etc). Edit the file again if necessary.'
-        success_message += (
-            self._symbol_navigator.get_out_and_in_edges_suggestion(str(path))
-            + f'{NAVIGATION_TIPS}'
-            if self._symbol_navigator.is_enabled
-            else ''
-        )
         return CLIResult(
             output=success_message,
             prev_exist=True,

--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -222,10 +222,8 @@ class OHEditor:
             return CLIResult(
                 output=self._make_output(file_content, str(path), start_line)
                 + (
-                    self._symbol_navigator.get_out_and_in_edges_suggestion(str(path))
-                    + NAVIGATION_TIPS
-                    if self._symbol_navigator.is_enabled
-                    else ''
+                    # self._symbol_navigator.get_out_and_in_edges_suggestion(str(path))
+                    NAVIGATION_TIPS if self._symbol_navigator.is_enabled else ''
                 ),
                 path=str(path),
                 prev_exist=True,
@@ -271,10 +269,8 @@ class OHEditor:
             path=str(path),
             output=self._make_output(file_content, str(path), start_line)
             + (
-                self._symbol_navigator.get_out_and_in_edges_suggestion(str(path))
-                + NAVIGATION_TIPS
-                if self._symbol_navigator.is_enabled
-                else ''
+                # self._symbol_navigator.get_out_and_in_edges_suggestion(str(path))
+                NAVIGATION_TIPS if self._symbol_navigator.is_enabled else ''
             ),
             prev_exist=True,
         )

--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -167,7 +167,10 @@ class OHEditor:
 
         success_message += 'Review the changes and make sure they are as expected. Edit the file again if necessary.'
         success_message += (
-            f'\n{NAVIGATION_TIPS}' if self._symbol_navigator.is_enabled else ''
+            self._symbol_navigator.get_out_and_in_edges_suggestion(str(path))
+            + f'{NAVIGATION_TIPS}'
+            if self._symbol_navigator.is_enabled
+            else ''
         )
         return CLIResult(
             output=success_message,
@@ -201,7 +204,12 @@ class OHEditor:
         if not view_range:
             return CLIResult(
                 output=self._make_output(file_content, str(path), start_line)
-                + (NAVIGATION_TIPS if self._symbol_navigator.is_enabled else '')
+                + (
+                    self._symbol_navigator.get_out_and_in_edges_suggestion(str(path))
+                    + NAVIGATION_TIPS
+                    if self._symbol_navigator.is_enabled
+                    else ''
+                )
             )
 
         if len(view_range) != 2 or not all(isinstance(i, int) for i in view_range):
@@ -239,9 +247,15 @@ class OHEditor:
             file_content = '\n'.join(file_content_lines[start_line - 1 :])
         else:
             file_content = '\n'.join(file_content_lines[start_line - 1 : end_line])
+
         return CLIResult(
             output=self._make_output(file_content, str(path), start_line)
-            + (NAVIGATION_TIPS if self._symbol_navigator.is_enabled else '')
+            + (
+                self._symbol_navigator.get_out_and_in_edges_suggestion(str(path))
+                + NAVIGATION_TIPS
+                if self._symbol_navigator.is_enabled
+                else ''
+            )
         )
 
     def write_file(self, path: Path, file_text: str) -> None:
@@ -310,7 +324,10 @@ class OHEditor:
 
         success_message += 'Review the changes and make sure they are as expected (correct indentation, no duplicate lines, etc). Edit the file again if necessary.'
         success_message += (
-            f'\n{NAVIGATION_TIPS}' if self._symbol_navigator.is_enabled else ''
+            self._symbol_navigator.get_out_and_in_edges_suggestion(str(path))
+            + f'{NAVIGATION_TIPS}'
+            if self._symbol_navigator.is_enabled
+            else ''
         )
         return CLIResult(
             output=success_message,

--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -196,9 +196,11 @@ class OHEditor:
             )
             if not stderr:
                 if self._symbol_navigator.is_enabled:
+                    path_depth = len(path.parts)
                     all_abs_paths_list = stdout.split('\n')
                     abs_path_to_skeleton = self._symbol_navigator.get_skeletons(
-                        all_abs_paths_list
+                        all_abs_paths_list,
+                        path_depth,
                     )
                     stdout = '\n'.join(
                         [

--- a/openhands_aci/editor/navigator.py
+++ b/openhands_aci/editor/navigator.py
@@ -54,6 +54,8 @@ class SymbolNavigator:
 
     @property
     def is_enabled(self):
+        if self._git_repo_found is None:
+            self.git_utils  # Initialize the git_utils
         return bool(self._git_repo_found)
 
     def get_definitions_tree(

--- a/openhands_aci/editor/navigator.py
+++ b/openhands_aci/editor/navigator.py
@@ -298,13 +298,13 @@ class SymbolNavigator:
         for tag in tags + [dummy_tag]:  # Add dummy tag to trigger last file output
             if tag.rel_path != cur_rel_file:
                 if lines_of_interest:
-                    output += cur_rel_file + ':\n'
+                    output += cur_rel_file + ':\n' if prepend_file_name else ''
                     output += self._render_tree(
                         cur_abs_file, cur_rel_file, lines_of_interest
                     )
                     lines_of_interest = []
                 elif cur_rel_file:  # No line of interest
-                    output += '\n' + cur_rel_file + ':\n'
+                    output += '\n' + cur_rel_file + ':\n' if prepend_file_name else ''
 
                 cur_abs_file = tag.abs_path
                 cur_rel_file = tag.rel_path

--- a/openhands_aci/editor/navigator.py
+++ b/openhands_aci/editor/navigator.py
@@ -174,7 +174,7 @@ class SymbolNavigator:
         in_files_w_idents = group_files_with_idents(in_files_w_idents)
 
         if len(out_files_w_idents) > 0:
-            suggestion_out = '\nFiles that this file uses:\n'
+            suggestion_out = '\nFiles Used By This File:\n'
             for file, ident in out_files_w_idents:
                 if file == rel_file_path:
                     continue
@@ -183,7 +183,7 @@ class SymbolNavigator:
             suggestion_out = ''
 
         if len(in_files_w_idents) > 0:
-            suggestion_in = '\nFiles that refer to this file:\n'
+            suggestion_in = '\nFiles Referencing This File:\n'
             for file, ident in in_files_w_idents:
                 if file == rel_file_path:
                     continue

--- a/openhands_aci/editor/navigator.py
+++ b/openhands_aci/editor/navigator.py
@@ -28,17 +28,20 @@ class SymbolNavigator:
     @property
     def git_utils(self):
         if self._git_repo_found is None:
-            if self._git_utils is None:
-                try:
-                    self._git_utils = GitRepoUtils(
-                        os.getcwd()
-                    )  # pwd is set to the workspace automatically
-                    self._git_repo_found = True
-                except Exception:
-                    self._git_repo_found = False
-                    return None
+            try:
+                self._git_utils = GitRepoUtils(
+                    os.getcwd()
+                )  # pwd is set to the workspace automatically
+                self._git_repo_found = True
+            except Exception:
+                self._git_repo_found = False
+                return None
+
             return self._git_utils
-        return None
+
+        if not self._git_repo_found:
+            return None
+        return self._git_utils
 
     @property
     def path_utils(self):

--- a/openhands_aci/editor/navigator.py
+++ b/openhands_aci/editor/navigator.py
@@ -6,6 +6,8 @@ from grep_ast import TreeContext
 from rapidfuzz import process
 from tqdm import tqdm
 
+from openhands_aci.editor.config import MAX_RESPONSE_LEN_CHAR
+from openhands_aci.editor.prompts import SKELETON_CONTENT_TRUNCATED_NOTICE
 from openhands_aci.tree_sitter.parser import ParsedTag, TagKind, TreeSitterParser
 from openhands_aci.utils.file import GitRepoUtils, get_modified_time, read_text
 from openhands_aci.utils.path import PathUtils
@@ -178,7 +180,7 @@ class SymbolNavigator:
 
         return suggestion_out + suggestion_in
 
-    def get_skeletons(self, all_abs_paths: list[str]) -> dict[str, str]:
+    def get_skeletons(self, all_abs_paths: list[str], depth: int) -> dict[str, str]:
         all_abs_tracked_files = self.git_utils.get_all_absolute_tracked_files()
 
         # Filter out the files that are tracked by the git repo
@@ -187,7 +189,6 @@ class SymbolNavigator:
         )
 
         abs_path_to_tree_repr = {}
-
         for abs_path in all_abs_paths:
             rel_path = self.path_utils.get_relative_path_str(abs_path)
             parsed_tags = self.ts_parser.get_tags_from_file(abs_path, rel_path)
@@ -195,6 +196,46 @@ class SymbolNavigator:
 
             abs_path_to_tree_repr[abs_path] = self._tag_list_to_tree(
                 def_tags, use_end_line=False, prepend_file_name=False
+            )
+
+        # Count length of all paths only
+        all_abs_paths_str = '\n'.join(all_abs_paths)
+        skeleton_max_len = MAX_RESPONSE_LEN_CHAR * depth - len(
+            all_abs_paths_str
+        )  # Allow more tokens as the agent views deeper directories
+        avg_len_per_path = skeleton_max_len // len(all_abs_paths)
+
+        # Content trunction: for all files where skeleton length is less than the average length, include the
+        # full skeleton. Otherwise, include proportional to the length of the file.
+        tree_repr_full = {}
+        tree_to_truncate = {}
+        for abs_path, tree_repr in abs_path_to_tree_repr.items():
+            if len(tree_repr) < avg_len_per_path:
+                tree_repr_full[abs_path] = tree_repr
+            else:
+                tree_to_truncate[abs_path] = tree_repr
+
+        # Calculate the total length of the full skeletons
+        total_len_full_skeletons = sum(
+            len(tree_repr) for tree_repr in tree_repr_full.values()
+        )
+        # Calculate total actual length of the to-truncate skeletons
+        total_len_to_truncate_skeletons = sum(
+            len(tree_repr) for tree_repr in tree_to_truncate.values()
+        )
+        # Calculate the max length of the truncated skeletons
+        max_len_truncated_skeletons = skeleton_max_len - total_len_full_skeletons
+
+        # Perform truncation with proportional length
+        for abs_path, tree_repr in tree_to_truncate.items():
+            tree_repr_len = len(tree_repr)
+            tree_repr_truncated_len = int(
+                (tree_repr_len / total_len_to_truncate_skeletons)
+                * max_len_truncated_skeletons
+            )
+            tree_repr_truncated = tree_repr[:tree_repr_truncated_len]
+            abs_path_to_tree_repr[abs_path] = (
+                tree_repr_truncated + SKELETON_CONTENT_TRUNCATED_NOTICE
             )
 
         return abs_path_to_tree_repr

--- a/openhands_aci/editor/navigator.py
+++ b/openhands_aci/editor/navigator.py
@@ -19,9 +19,7 @@ class SymbolNavigator:
         self._git_utils: GitRepoUtils | None = None
         self._path_utils: PathUtils | None = None
         self._ts_parser: TreeSitterParser | None = None
-        self._git_repo_found = (
-            True  # Used to disable the 2 navigation commands if no git repo is found
-        )
+        self._git_repo_found: bool | None = None
 
         # Caching
         self.file_context_cache: dict = {}  # (rel_file) -> {'context': TreeContext_obj, 'mtime': mtime})
@@ -29,12 +27,13 @@ class SymbolNavigator:
 
     @property
     def git_utils(self):
-        if self._git_repo_found:
+        if self._git_repo_found is None:
             if self._git_utils is None:
                 try:
                     self._git_utils = GitRepoUtils(
                         os.getcwd()
                     )  # pwd is set to the workspace automatically
+                    self._git_repo_found = True
                 except Exception:
                     self._git_repo_found = False
                     return None
@@ -55,7 +54,7 @@ class SymbolNavigator:
 
     @property
     def is_enabled(self):
-        return self._git_repo_found
+        return bool(self._git_repo_found)
 
     def get_definitions_tree(
         self, symbol: str, rel_file_path: str | None = None, use_end_line=True

--- a/openhands_aci/editor/navigator.py
+++ b/openhands_aci/editor/navigator.py
@@ -28,9 +28,15 @@ class SymbolNavigator:
     @property
     def git_utils(self):
         if self._git_repo_found is None:
+            pwd = os.getcwd()
+            if pwd == '/testbed':
+                # Symlink used in swe-bench evaluation
+                workspace_dir = '/workspace'
+                pwd = workspace_dir + '/' + os.listdir(workspace_dir)[0]
+
             try:
                 self._git_utils = GitRepoUtils(
-                    os.getcwd()
+                    pwd
                 )  # pwd is set to the workspace automatically
                 self._git_repo_found = True
             except Exception:
@@ -46,13 +52,25 @@ class SymbolNavigator:
     @property
     def path_utils(self):
         if self._path_utils is None:
-            self._path_utils = PathUtils(os.getcwd())
+            pwd = os.getcwd()
+            if pwd == '/testbed':
+                # Symlink used in swe-bench evaluation
+                workspace_dir = '/workspace'
+                pwd = workspace_dir + '/' + os.listdir(workspace_dir)[0]
+
+            self._path_utils = PathUtils(pwd)
         return self._path_utils
 
     @property
     def ts_parser(self):
         if self._ts_parser is None:
-            self._ts_parser = TreeSitterParser(os.getcwd())
+            pwd = os.getcwd()
+            if pwd == '/testbed':
+                # Symlink used in swe-bench evaluation
+                workspace_dir = '/workspace'
+                pwd = workspace_dir + '/' + os.listdir(workspace_dir)[0]
+
+            self._ts_parser = TreeSitterParser(pwd)
         return self._ts_parser
 
     @property

--- a/openhands_aci/editor/prompts.py
+++ b/openhands_aci/editor/prompts.py
@@ -1,3 +1,5 @@
 CONTENT_TRUNCATED_NOTICE: str = '<response clipped><NOTE>To save on context only part of this file has been shown to you. You should retry this tool after you have searched inside the file with `grep -n` in order to find the line numbers of what you are looking for.</NOTE>'
 
+SKELETON_CONTENT_TRUNCATED_NOTICE: str = '<response clipped><NOTE>To save on context only part of the full file skeleton has been shown to you. Use view command to see the remaining content.</NOTE>'
+
 NAVIGATION_TIPS: str = '<TIP>Use the `jump_to_definition` and `find_references` commands to understand more about those class, function/method and how they are used in the codebase.</TIP>'

--- a/openhands_aci/editor/prompts.py
+++ b/openhands_aci/editor/prompts.py
@@ -1,3 +1,3 @@
 CONTENT_TRUNCATED_NOTICE: str = '<response clipped><NOTE>To save on context only part of this file has been shown to you. You should retry this tool after you have searched inside the file with `grep -n` in order to find the line numbers of what you are looking for.</NOTE>'
 
-NAVIGATION_TIPS: str = '<TIP>Use the `jump_to_definition` and `find_references` commands to understand more about a particular class, function/method and how it is used in the codebase.</TIP>'
+NAVIGATION_TIPS: str = '<TIP>Use the `jump_to_definition` and `find_references` commands to understand more about those class, function/method and how they are used in the codebase.</TIP>'

--- a/tests/integration/test_file_editor.py
+++ b/tests/integration/test_file_editor.py
@@ -4,7 +4,6 @@ import re
 import pytest
 
 from openhands_aci.editor import file_editor
-from openhands_aci.editor.prompts import NAVIGATION_TIPS
 
 
 @pytest.fixture
@@ -41,8 +40,7 @@ def test_file_editor_happy_path(temp_file):
         == f"""The file {temp_file} has been edited. Here's the result of running `cat -n` on a snippet of {temp_file}:
      1\tThis is a sample file.
      2\tThis file is for testing purposes.
-Review the changes and make sure they are as expected. Edit the file again if necessary.
-{NAVIGATION_TIPS}"""
+Review the changes and make sure they are as expected. Edit the file again if necessary."""
     )
     assert result_dict['path'] == temp_file
     assert result_dict['prev_exist'] is True

--- a/tests/integration/test_file_editor.py
+++ b/tests/integration/test_file_editor.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 
 import pytest
@@ -8,6 +9,8 @@ from openhands_aci.editor import file_editor
 
 @pytest.fixture
 def temp_file(tmp_path):
+    os.chdir(tmp_path)
+
     # Set up a temporary directory with test files
     test_file = tmp_path / 'test_file.txt'
     test_file.write_text('This is a test file.\nThis file is for testing purposes.')

--- a/tests/integration/test_oh_editor.py
+++ b/tests/integration/test_oh_editor.py
@@ -8,7 +8,6 @@ from openhands_aci.editor.exceptions import (
     EditorToolParameterMissingError,
     ToolError,
 )
-from openhands_aci.editor.prompts import NAVIGATION_TIPS
 from openhands_aci.editor.results import CLIResult, ToolResult
 
 
@@ -75,8 +74,7 @@ def test_str_replace_no_linting(editor):
         == f"""The file {test_file} has been edited. Here's the result of running `cat -n` on a snippet of {test_file}:
      1\tThis is a sample file.
      2\tThis file is for testing purposes.
-Review the changes and make sure they are as expected. Edit the file again if necessary.
-{NAVIGATION_TIPS}"""
+Review the changes and make sure they are as expected. Edit the file again if necessary."""
     )
 
     # Test that the file content has been updated
@@ -99,8 +97,7 @@ def test_str_replace_multi_line_no_linting(editor):
         == f"""The file {test_file} has been edited. Here's the result of running `cat -n` on a snippet of {test_file}:
      1\tThis is a sample file.
      2\tThis file is for testing purposes.
-Review the changes and make sure they are as expected. Edit the file again if necessary.
-{NAVIGATION_TIPS}"""
+Review the changes and make sure they are as expected. Edit the file again if necessary."""
     )
 
 
@@ -119,8 +116,7 @@ def test_str_replace_multi_line_with_tabs_no_linting(editor_python_file_with_tab
         == f"""The file {test_file} has been edited. Here's the result of running `cat -n` on a snippet of {test_file}:
      1\tdef test():
      2\t{'\t'.expandtabs()}print("Hello, Universe!")
-Review the changes and make sure they are as expected. Edit the file again if necessary.
-{NAVIGATION_TIPS}"""
+Review the changes and make sure they are as expected. Edit the file again if necessary."""
     )
 
 
@@ -143,8 +139,7 @@ def test_str_replace_with_linting(editor):
      2\tThis file is for testing purposes.
 
 No linting issues found in the changes.
-Review the changes and make sure they are as expected. Edit the file again if necessary.
-{NAVIGATION_TIPS}"""
+Review the changes and make sure they are as expected. Edit the file again if necessary."""
     )
 
     # Test that the file content has been updated
@@ -189,8 +184,7 @@ def test_insert_no_linting(editor):
      1\tThis is a test file.
      2\tInserted line
      3\tThis file is for testing purposes.
-Review the changes and make sure they are as expected (correct indentation, no duplicate lines, etc). Edit the file again if necessary.
-{NAVIGATION_TIPS}"""
+Review the changes and make sure they are as expected (correct indentation, no duplicate lines, etc). Edit the file again if necessary."""
     )
 
 
@@ -214,8 +208,7 @@ def test_insert_with_linting(editor):
      3\tThis file is for testing purposes.
 
 No linting issues found in the changes.
-Review the changes and make sure they are as expected (correct indentation, no duplicate lines, etc). Edit the file again if necessary.
-{NAVIGATION_TIPS}"""
+Review the changes and make sure they are as expected (correct indentation, no duplicate lines, etc). Edit the file again if necessary."""
     )
 
 

--- a/tests/integration/test_oh_editor.py
+++ b/tests/integration/test_oh_editor.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from openhands_aci.editor.editor import OHEditor
@@ -12,6 +14,7 @@ from openhands_aci.editor.results import CLIResult, ToolResult
 
 @pytest.fixture
 def editor(tmp_path):
+    os.chdir(tmp_path)
     editor = OHEditor()
     # Set up a temporary directory with test files
     test_file = tmp_path / 'test.txt'
@@ -21,6 +24,7 @@ def editor(tmp_path):
 
 @pytest.fixture
 def editor_python_file_with_tabs(tmp_path):
+    os.chdir(tmp_path)
     editor = OHEditor()
     # Set up a temporary directory with test files
     test_file = tmp_path / 'test.py'


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This PR is to:
- Improve upon the existing `view` command implementation.

Some remaining TODOs:
- [x] Max token control
- [ ] Symbol ranking to choose what to show

### `view` command on a file path

```
{
    "command": "view", 
    "path": "/home/hoang/openhands-aci/openhands_aci/utils/shell.py"
}
```

<details>
<summary>New output with navigation suggestion</summary>

```
Here's the result of running `cat -n` on /home/hoang/openhands-aci/openhands_aci/
utils/shell.py:
     1  import os
     2  import subprocess
     3  import time
     4
     5  from openhands_aci.editor.config import MAX_RESPONSE_LEN_CHAR
     6  from openhands_aci.editor.results import maybe_truncate
     7
     8
     9  def run_shell_cmd(
    10      cmd: str,
    11      timeout: float | None = 120.0,  # seconds
    12      truncate_after: int | None = MAX_RESPONSE_LEN_CHAR,
    13  ) -> tuple[int, str, str]:
    14      """Run a shell command synchronously with a timeout.
    15
    16      Args:
    17          cmd: The shell command to run.
    18          timeout: The maximum time to wait for the command to complete.
    19          truncate_after: The maximum number of characters to return for stdout and stderr.
    20
    21      Returns:
    22          A tuple containing the return code, stdout, and stderr.
    23      """
    24
    25      start_time = time.time()
    26
    27      try:
    28          process = subprocess.Popen(
    29              cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
    30          )
    31
    32          stdout, stderr = process.communicate(timeout=timeout)
    33
    34          return (
    35              process.returncode or 0,
    36              maybe_truncate(stdout, truncate_after=truncate_after),
    37              maybe_truncate(stderr, truncate_after=truncate_after),
    38          )
    39      except subprocess.TimeoutExpired:
    40          process.kill()
    41          elapsed_time = time.time() - start_time
    42          raise TimeoutError(
    43              f"Command '{cmd}' timed out after {elapsed_time:.2f} seconds"
    44          )
    45
    46
    47  def check_tool_installed(tool_name: str) -> bool:
    48      """Check if a tool is installed."""
    49      try:
    50          subprocess.run(
    51              [tool_name, '--version'],
    52              check=True,
    53              cwd=os.getcwd(),
    54              stdout=subprocess.PIPE,
    55              stderr=subprocess.PIPE,
    56          )
    57          return True
    58      except (subprocess.CalledProcessError, FileNotFoundError):
    59          return False
    60

Files that this file uses:
- openhands_aci/editor/results.py (via `maybe_truncate`)

Files that refer to this file:
- tests/unit/test_shell_utils.py (via `run_shell_cmd`, `check_tool_installed`)
- openhands_aci/linter/impl/python.py (via `run_shell_cmd`)
- openhands_aci/editor/editor.py (via `run_shell_cmd`)
<TIP>Use the `jump_to_definition` and `find_references` commands to understand 
more about those class, function/method and how they are used in the codebase.</TIP>
```
</details>


### `view` command on a directory path

```
{
    "command": "view", 
    "path": "/home/hoang/openhands-aci/openhands_aci/utils"
}
```

<details>
<summary>New output with file skeleton</summary>

```
Here's the files with its skeleton (i.e., class, function/method signatures) and 
directories up to 2 levels deep in /home/hoang/openhands-aci/openhands_aci/utils, 
excluding hidden items:
/home/hoang/openhands-aci/openhands_aci/utils
/home/hoang/openhands-aci/openhands_aci/utils/file.py
...⋮...
  7│class GitRepoUtils:
  8│    def __init__(self, abs_repo_path: str) -> None:
  9│        from git import Repo
 10│
 11│        if not Path(abs_repo_path).is_absolute():
 12│            raise ValueError('The path must be absolute')
 13│
 14│        self.repo_path = Path(abs_repo_path)
 15│        try:
 16│            self.repo = Repo(self.repo_path)
 17│        except Exception:
...⋮...
 23│    def get_all_absolute_tracked_files(self, depth: int | None = None) -> list[str]:
...⋮...
 31│    def get_all_relative_tracked_files(self, depth: int | None = None) -> list[str]:
...⋮...
 39│    def get_all_absolute_staged_files(self) -> list[str]:
...⋮...
 44│    def get_absolute_tracked_files_in_directory(
 45│        self, rel_dir_path: str, depth: int | None = None
...⋮...
 57│def get_modified_time(abs_path: str) -> int:
...⋮...
 64│def read_text(abs_path: str) -> str:
...⋮...
/home/hoang/openhands-aci/openhands_aci/utils/shell.py
...⋮...
  9│def run_shell_cmd(
 10│    cmd: str,
 11│    timeout: float | None = 120.0,  # seconds
 12│    truncate_after: int | None = MAX_RESPONSE_LEN_CHAR,
...⋮...
 47│def check_tool_installed(tool_name: str) -> bool:
...⋮...
/home/hoang/openhands-aci/openhands_aci/utils/logger.py

/home/hoang/openhands-aci/openhands_aci/utils/diff.py
...⋮...
  6│def get_diff(old_contents: str, new_contents: str, filepath: str = 'file') -> str:
...⋮...
 21│def parse_diff(diff_patch: str) -> list[whatthepatch.patch.Change]:
...⋮...
/home/hoang/openhands-aci/openhands_aci/utils/__pycache__
/home/hoang/openhands-aci/openhands_aci/utils/__pycache__/path.cpython-312.pyc
/home/hoang/openhands-aci/openhands_aci/utils/__pycache__/shell.cpython-312.pyc
/home/hoang/openhands-aci/openhands_aci/utils/__pycache__/diff.cpython-312.pyc
/home/hoang/openhands-aci/openhands_aci/utils/__pycache__/file.cpython-312.pyc
/home/hoang/openhands-aci/openhands_aci/utils/__pycache__/logger.cpython-312.pyc
/home/hoang/openhands-aci/openhands_aci/utils/path.py
...⋮...
  4│class PathUtils:
  5│    def __init__(self, root: str) -> None:
...⋮...
  8│    def get_absolute_path_str(self, rel_path: str) -> str:
...⋮...
 11│    def get_relative_path_str(self, abs_path: str) -> str:
...⋮...
 14│    def get_depth_from_root(self, abs_path: str) -> int:
...⋮...
 18│def has_image_extension(path: str) -> bool:
...⋮...
 23│def get_depth_of_rel_path(rel_path: str) -> int:
...⋮...
```
</details>

## Related Issue

This can be seen as an alternative to the original `RepoMap`. Progress towards https://github.com/All-Hands-AI/OpenHands/issues/2185 
