### PR TITLE
Fix directory view to follow symlinks

### DIFF
--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -173,7 +173,7 @@ class OHEditor:
                 )
 
             _, stdout, stderr = run_shell_cmd(
-                rf"find {path} -maxdepth 2 -not -path '*/\.*'"
+                rf"find -L {path} -maxdepth 2 -not -path '*/\.*'"
             )
             if not stderr:
                 stdout = f"Here's the files and directories up to 2 levels deep in {path}, excluding hidden items:\n{stdout}\n"

--- a/tests/integration/test_oh_editor.py
+++ b/tests/integration/test_oh_editor.py
@@ -311,25 +311,25 @@ def test_undo_edit_no_history_error(editor):
 
 def test_view_symlinked_directory(tmp_path):
     editor = OHEditor()
-    
+
     # Create a directory with some test files
     source_dir = tmp_path / 'source_dir'
     source_dir.mkdir()
     (source_dir / 'file1.txt').write_text('content1')
     (source_dir / 'file2.txt').write_text('content2')
-    
+
     # Create a subdirectory with a file
     subdir = source_dir / 'subdir'
     subdir.mkdir()
     (subdir / 'file3.txt').write_text('content3')
-    
+
     # Create a symlink to the directory
     symlink_dir = tmp_path / 'symlink_dir'
     symlink_dir.symlink_to(source_dir)
-    
+
     # View the symlinked directory
     result = editor(command='view', path=str(symlink_dir))
-    
+
     # Verify that all files are listed through the symlink
     assert isinstance(result, CLIResult)
     assert str(symlink_dir) in result.output

--- a/tests/integration/test_oh_editor.py
+++ b/tests/integration/test_oh_editor.py
@@ -307,3 +307,33 @@ def test_undo_edit_no_history_error(editor):
     empty_file.write_text('')
     with pytest.raises(ToolError):
         editor(command='undo_edit', path=str(empty_file))
+
+
+def test_view_symlinked_directory(tmp_path):
+    editor = OHEditor()
+    
+    # Create a directory with some test files
+    source_dir = tmp_path / 'source_dir'
+    source_dir.mkdir()
+    (source_dir / 'file1.txt').write_text('content1')
+    (source_dir / 'file2.txt').write_text('content2')
+    
+    # Create a subdirectory with a file
+    subdir = source_dir / 'subdir'
+    subdir.mkdir()
+    (subdir / 'file3.txt').write_text('content3')
+    
+    # Create a symlink to the directory
+    symlink_dir = tmp_path / 'symlink_dir'
+    symlink_dir.symlink_to(source_dir)
+    
+    # View the symlinked directory
+    result = editor(command='view', path=str(symlink_dir))
+    
+    # Verify that all files are listed through the symlink
+    assert isinstance(result, CLIResult)
+    assert str(symlink_dir) in result.output
+    assert 'file1.txt' in result.output
+    assert 'file2.txt' in result.output
+    assert 'subdir' in result.output
+    assert 'file3.txt' in result.output


### PR DESCRIPTION
## Description

This PR is to:
- Fix the view command in `editor.py` to properly handle symlinked directories by adding the `-L` option to the `find` command.
- Add test case to verify symlink directory viewing functionality

## Related Issue

https://github.com/All-Hands-AI/OpenHands/issues/5497
