### PR TITLE
Use a dynamic marker for structured output

### DIFF
--- a/openhands_aci/editor/__init__.py
+++ b/openhands_aci/editor/__init__.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 
 from .editor import Command, OHEditor
 from .exceptions import ToolError
@@ -41,6 +42,7 @@ def file_editor(
         return _make_api_tool_result(ToolResult(error=e.message))
 
     formatted_output_and_error = _make_api_tool_result(result)
-    return f"""<oh_aci_output>
+    marker_id = uuid.uuid4().hex
+    return f"""<oh_aci_output_{marker_id}>
 {json.dumps(result.to_dict(extra_field={'formatted_output_and_error': formatted_output_and_error}), indent=2)}
-</oh_aci_output>"""
+</oh_aci_output_{marker_id}>"""

--- a/tests/integration/test_file_editor.py
+++ b/tests/integration/test_file_editor.py
@@ -29,7 +29,11 @@ def test_file_editor_happy_path(temp_file):
     )
 
     # Extract the JSON content using a regular expression
-    match = re.search(r'<oh_aci_output>(.*?)</oh_aci_output>', result, re.DOTALL)
+    match = re.search(
+        r'<oh_aci_output_[0-9a-f]{32}>(.*?)</oh_aci_output_[0-9a-f]{32}>',
+        result,
+        re.DOTALL,
+    )
     assert match, 'Output does not contain the expected <oh_aci_output> tags.'
     result_dict = json.loads(match.group(1))
 

--- a/tests/integration/test_file_editor.py
+++ b/tests/integration/test_file_editor.py
@@ -34,7 +34,7 @@ def test_file_editor_happy_path(temp_file):
         result,
         re.DOTALL,
     )
-    assert match, 'Output does not contain the expected <oh_aci_output> tags.'
+    assert match, 'Output does not contain the expected <oh_aci_output_> tags in the correct format.'
     result_dict = json.loads(match.group(1))
 
     # Validate the formatted output in the result dictionary
@@ -61,3 +61,50 @@ Review the changes and make sure they are as expected. Edit the file again if ne
     with open(temp_file, 'r') as f:
         content = f.read()
     assert 'This is a sample file.' in content
+
+
+def test_file_editor_with_xml_tag_parsing(temp_file):
+    # Create content that includes the XML tag pattern
+    xml_content = """This is a file with XML tags parsing logic...
+match = re.search(
+    r'<oh_aci_output_[0-9a-f]{32}>(.*?)</oh_aci_output_[0-9a-f]{32}>',
+    result,
+    re.DOTALL,
+)
+...More text here.
+"""
+
+    with open(temp_file, 'w') as f:
+        f.write(xml_content)
+
+    result = file_editor(
+        command='view',
+        path=temp_file,
+    )
+
+    # Ensure the content is extracted correctly
+    match = re.search(
+        r'<oh_aci_output_[0-9a-f]{32}>(.*?)</oh_aci_output_[0-9a-f]{32}>',
+        result,
+        re.DOTALL,
+    )
+
+    assert match, 'Output does not contain the expected <oh_aci_output_> tags in the correct format.'
+    result_dict = json.loads(match.group(1))
+
+    # Validate the formatted output in the result dictionary
+    formatted_output = result_dict['formatted_output_and_error']
+    print(formatted_output)
+    assert (
+        formatted_output
+        == f"""Here's the result of running `cat -n` on {temp_file}:
+     1\tThis is a file with XML tags parsing logic...
+     2\tmatch = re.search(
+     3\t    r'<oh_aci_output_[0-9a-f]{{32}}>(.*?)</oh_aci_output_[0-9a-f]{{32}}>',
+     4\t    result,
+     5\t    re.DOTALL,
+     6\t)
+     7\t...More text here.
+     8\t
+"""
+    )


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This PR is to:
- Use a dynamic marker for the structured output. Currently it uses a hard-coded `<oh_aci_output>` tag. This is problematic when the obs content contains that exact string, as it will interfere with the regex parsing process.

## Related Issue
<!--- Use the keywords 'Close', 'Closes', 'Fix', or 'Fixes' followed by the issue number(s) to close the related issue(s) -->

https://github.com/All-Hands-AI/OpenHands/issues/5479.


