### PR TITLE
fix: missing `new_str` field in `create` command output

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 10
     groups:
       python-packages:

--- a/openhands_aci/editor/__init__.py
+++ b/openhands_aci/editor/__init__.py
@@ -27,6 +27,7 @@ def file_editor(
     insert_line: int | None = None,
     enable_linting: bool = False,
 ) -> str:
+    result: ToolResult | None = None
     try:
         result = _GLOBAL_EDITOR(
             command=command,
@@ -39,7 +40,7 @@ def file_editor(
             enable_linting=enable_linting,
         )
     except ToolError as e:
-        return _make_api_tool_result(ToolResult(error=e.message))
+        result = ToolResult(error=e.message)
 
     formatted_output_and_error = _make_api_tool_result(result)
     marker_id = uuid.uuid4().hex

--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -67,6 +67,7 @@ class OHEditor:
             self._file_history[_path].append(file_text)
             return CLIResult(
                 path=str(_path),
+                new_content=file_text,
                 prev_exist=False,
                 output=f'File created successfully at: {_path}',
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openhands-aci"
-version = "0.1.3"
+version = "0.1.4"
 description = "An Agent-Computer Interface (ACI) designed for software development agents OpenHands."
 authors = ["OpenHands"]
 license = "MIT"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This PR is to:
- Add missing `new_str` field in `create` command output. The current missing `new_str` field causes the action to be mapped to `FileReadAction` instead of `FileEditAction` in OH.
- Add error message into formatted output.
- Bump to 0.1.4.
