### PR TITLE
fix: use None check instead of falsy

### DIFF
--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -61,7 +61,7 @@ class OHEditor:
         if command == 'view':
             return self.view(_path, view_range)
         elif command == 'create':
-            if not file_text:
+            if file_text is None:
                 raise EditorToolParameterMissingError(command, 'file_text')
             self.write_file(_path, file_text)
             self._file_history[_path].append(file_text)
@@ -72,7 +72,7 @@ class OHEditor:
                 output=f'File created successfully at: {_path}',
             )
         elif command == 'str_replace':
-            if not old_str:
+            if old_str is None:
                 raise EditorToolParameterMissingError(command, 'old_str')
             if new_str == old_str:
                 raise EditorToolParameterInvalidError(
@@ -84,7 +84,7 @@ class OHEditor:
         elif command == 'insert':
             if insert_line is None:
                 raise EditorToolParameterMissingError(command, 'insert_line')
-            if not new_str:
+            if new_str is None:
                 raise EditorToolParameterMissingError(command, 'new_str')
             return self.insert(_path, insert_line, new_str, enable_linting)
         elif command == 'undo_edit':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openhands-aci"
-version = "0.1.4"
+version = "0.1.5"
 description = "An Agent-Computer Interface (ACI) designed for software development agents OpenHands."
 authors = ["OpenHands"]
 license = "MIT"

--- a/tests/integration/test_oh_editor.py
+++ b/tests/integration/test_oh_editor.py
@@ -54,6 +54,24 @@ def test_create_file(editor):
     assert 'File created successfully' in result.output
 
 
+def test_create_with_empty_string(editor):
+    editor, test_file = editor
+    new_file = test_file.parent / 'empty_content.txt'
+    result = editor(command='create', path=str(new_file), file_text='')
+    assert isinstance(result, ToolResult)
+    assert new_file.exists()
+    assert new_file.read_text() == ''
+    assert 'File created successfully' in result.output
+
+
+def test_create_with_none_file_text(editor):
+    editor, test_file = editor
+    new_file = test_file.parent / 'none_content.txt'
+    with pytest.raises(EditorToolParameterMissingError) as exc_info:
+        editor(command='create', path=str(new_file), file_text=None)
+    assert 'file_text' in str(exc_info.value.message)
+
+
 def test_str_replace_no_linting(editor):
     editor, test_file = editor
     result = editor(
@@ -188,6 +206,31 @@ def test_str_replace_nonexistent_string(editor):
     )
 
 
+def test_str_replace_with_empty_string(editor):
+    editor, test_file = editor
+    test_file.write_text('Line 1\nLine to remove\nLine 3')
+    result = editor(
+        command='str_replace',
+        path=str(test_file),
+        old_str='Line to remove\n',
+        new_str='',
+    )
+    assert isinstance(result, CLIResult)
+    assert test_file.read_text() == 'Line 1\nLine 3'
+
+
+def test_str_replace_with_none_old_str(editor):
+    editor, test_file = editor
+    with pytest.raises(EditorToolParameterMissingError) as exc_info:
+        editor(
+            command='str_replace',
+            path=str(test_file),
+            old_str=None,
+            new_str='new content',
+        )
+    assert 'old_str' in str(exc_info.value.message)
+
+
 def test_insert_no_linting(editor):
     editor, test_file = editor
     result = editor(
@@ -243,6 +286,32 @@ def test_insert_invalid_line(editor):
     assert 'It should be within the range of lines of the file' in str(
         exc_info.value.message
     )
+
+
+def test_insert_with_empty_string(editor):
+    editor, test_file = editor
+    result = editor(
+        command='insert',
+        path=str(test_file),
+        insert_line=1,
+        new_str='',
+    )
+    assert isinstance(result, CLIResult)
+    content = test_file.read_text().splitlines()
+    assert '' in content
+    assert len(content) == 3  # Original 2 lines plus empty line
+
+
+def test_insert_with_none_new_str(editor):
+    editor, test_file = editor
+    with pytest.raises(EditorToolParameterMissingError) as exc_info:
+        editor(
+            command='insert',
+            path=str(test_file),
+            insert_line=1,
+            new_str=None,
+        )
+    assert 'new_str' in str(exc_info.value.message)
 
 
 def test_undo_edit(editor):


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Previously I raised a fix to the editor implementation in the OH repo, but forgot to fix it here: https://github.com/All-Hands-AI/OpenHands/pull/4705. This seems to degrade the performance on swe-bench a bit and causes the agent to stuck in the loop.