### PR TITLE
Show count of hidden files in view command

### DIFF
--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -186,7 +186,7 @@ class OHEditor:
             # Then get non-hidden files/dirs, excluding hidden files at all levels
             # We need to exclude both files/dirs starting with . and files/dirs under hidden dirs
             _, stdout, stderr = run_shell_cmd(
-                rf"find -L {path} -maxdepth 2 -not -path '*/\.*/*' -not -name '.*'",
+                rf"find -L {path} -maxdepth 2 -not -path '*/\.*'",
                 truncate_notice=DIRECTORY_CONTENT_TRUNCATED_NOTICE,
             )
             if not stderr:

--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -174,12 +174,22 @@ class OHEditor:
                     'The `view_range` parameter is not allowed when `path` points to a directory.',
                 )
 
+            # First count hidden files/dirs
+            _, hidden_stdout, _ = run_shell_cmd(
+                rf"find -L {path} -maxdepth 2 -path '*/\.*' -not -path '*/\.' -not -path '*/\..'"
+            )
+            hidden_count = len(hidden_stdout.strip().split('\n')) if hidden_stdout.strip() else 0
+
+            # Then get non-hidden files/dirs
             _, stdout, stderr = run_shell_cmd(
                 rf"find -L {path} -maxdepth 2 -not -path '*/\.*'",
                 truncate_notice=DIRECTORY_CONTENT_TRUNCATED_NOTICE,
             )
             if not stderr:
-                stdout = f"Here's the files and directories up to 2 levels deep in {path}, excluding hidden items:\n{stdout}\n"
+                msg = [f"Here's the files and directories up to 2 levels deep in {path}, excluding hidden items:\n{stdout}"]
+                if hidden_count > 0:
+                    msg.append(f"\n{hidden_count} hidden files/directories are excluded. You can use 'ls -la {path}' to see them.")
+                stdout = '\n'.join(msg)
             return CLIResult(
                 output=stdout,
                 error=stderr,

--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -195,7 +195,7 @@ class OHEditor:
                 ]
                 if hidden_count > 0:
                     msg.append(
-                        f"\n{hidden_count} hidden files/directories are excluded. You can use 'ls -la {path}' to see them."
+                        f"\n{hidden_count} hidden files/directories in this directory are excluded. You can use 'ls -la {path}' to see them."
                     )
                 stdout = '\n'.join(msg)
             return CLIResult(

--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -178,7 +178,9 @@ class OHEditor:
             _, hidden_stdout, _ = run_shell_cmd(
                 rf"find -L {path} -maxdepth 2 -path '*/\.*' -not -path '*/\.' -not -path '*/\..'"
             )
-            hidden_count = len(hidden_stdout.strip().split('\n')) if hidden_stdout.strip() else 0
+            hidden_count = (
+                len(hidden_stdout.strip().split('\n')) if hidden_stdout.strip() else 0
+            )
 
             # Then get non-hidden files/dirs
             _, stdout, stderr = run_shell_cmd(
@@ -186,9 +188,13 @@ class OHEditor:
                 truncate_notice=DIRECTORY_CONTENT_TRUNCATED_NOTICE,
             )
             if not stderr:
-                msg = [f"Here's the files and directories up to 2 levels deep in {path}, excluding hidden items:\n{stdout}"]
+                msg = [
+                    f"Here's the files and directories up to 2 levels deep in {path}, excluding hidden items:\n{stdout}"
+                ]
                 if hidden_count > 0:
-                    msg.append(f"\n{hidden_count} hidden files/directories are excluded. You can use 'ls -la {path}' to see them.")
+                    msg.append(
+                        f"\n{hidden_count} hidden files/directories are excluded. You can use 'ls -la {path}' to see them."
+                    )
                 stdout = '\n'.join(msg)
             return CLIResult(
                 output=stdout,

--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -175,8 +175,9 @@ class OHEditor:
                 )
 
             # First count hidden files/dirs in current directory only
+            # -mindepth 1 excludes . and .. automatically
             _, hidden_stdout, _ = run_shell_cmd(
-                rf"find -L {path} -maxdepth 1 -path '{path}/\.*' -not -path '{path}/\.' -not -path '{path}/\..'"
+                rf"find -L {path} -mindepth 1 -maxdepth 1 -name '.*'"
             )
             hidden_count = (
                 len(hidden_stdout.strip().split('\n')) if hidden_stdout.strip() else 0

--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -174,17 +174,18 @@ class OHEditor:
                     'The `view_range` parameter is not allowed when `path` points to a directory.',
                 )
 
-            # First count hidden files/dirs
+            # First count hidden files/dirs in current directory only
             _, hidden_stdout, _ = run_shell_cmd(
-                rf"find -L {path} -maxdepth 2 -path '{path}/\.*' -not -path '{path}/\.' -not -path '{path}/\..'"
+                rf"find -L {path} -maxdepth 1 -path '{path}/\.*' -not -path '{path}/\.' -not -path '{path}/\..'"
             )
             hidden_count = (
                 len(hidden_stdout.strip().split('\n')) if hidden_stdout.strip() else 0
             )
 
-            # Then get non-hidden files/dirs
+            # Then get non-hidden files/dirs, excluding hidden files at all levels
+            # We need to exclude both files/dirs starting with . and files/dirs under hidden dirs
             _, stdout, stderr = run_shell_cmd(
-                rf"find -L {path} -maxdepth 2 -not -path '{path}/\.*'",
+                rf"find -L {path} -maxdepth 2 -not -path '*/\.*/*' -not -name '.*'",
                 truncate_notice=DIRECTORY_CONTENT_TRUNCATED_NOTICE,
             )
             if not stderr:

--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -176,7 +176,7 @@ class OHEditor:
 
             # First count hidden files/dirs
             _, hidden_stdout, _ = run_shell_cmd(
-                rf"find -L {path} -maxdepth 2 -path '*/\.*' -not -path '*/\.' -not -path '*/\..'"
+                rf"find -L {path} -maxdepth 2 -path '{path}/\.*' -not -path '{path}/\.' -not -path '{path}/\..'"
             )
             hidden_count = (
                 len(hidden_stdout.strip().split('\n')) if hidden_stdout.strip() else 0
@@ -184,7 +184,7 @@ class OHEditor:
 
             # Then get non-hidden files/dirs
             _, stdout, stderr = run_shell_cmd(
-                rf"find -L {path} -maxdepth 2 -not -path '*/\.*'",
+                rf"find -L {path} -maxdepth 2 -not -path '{path}/\.*'",
                 truncate_notice=DIRECTORY_CONTENT_TRUNCATED_NOTICE,
             )
             if not stderr:

--- a/tests/integration/test_oh_editor.py
+++ b/tests/integration/test_oh_editor.py
@@ -417,7 +417,9 @@ def test_view_directory_with_hidden_files(tmp_path):
     assert '.hidden1' not in result.output  # Hidden files not shown
     assert '.hidden2' not in result.output
     assert '.hidden_dir' not in result.output
-    assert '.hidden_in_subdir' not in result.output  # Hidden file in visible dir not shown
+    assert (
+        '.hidden_in_subdir' not in result.output
+    )  # Hidden file in visible dir not shown
     assert (
         '3 hidden files/directories are excluded' in result.output
     )  # Shows count of hidden items in current dir only

--- a/tests/integration/test_oh_editor.py
+++ b/tests/integration/test_oh_editor.py
@@ -46,6 +46,8 @@ def test_view_directory(editor):
     assert isinstance(result, CLIResult)
     assert str(test_file.parent) in result.output
     assert test_file.name in result.output
+    assert 'excluding hidden items' in result.output
+    assert '0 hidden files/directories are excluded' not in result.output  # No message when no hidden files
 
 
 def test_create_file(editor):
@@ -380,6 +382,35 @@ def test_undo_edit_no_history_error(editor):
     empty_file.write_text('')
     with pytest.raises(ToolError):
         editor(command='undo_edit', path=str(empty_file))
+
+
+def test_view_directory_with_hidden_files(tmp_path):
+    editor = OHEditor()
+
+    # Create a directory with some test files
+    test_dir = tmp_path / 'test_dir'
+    test_dir.mkdir()
+    (test_dir / 'visible.txt').write_text('content1')
+    (test_dir / '.hidden1').write_text('hidden1')
+    (test_dir / '.hidden2').write_text('hidden2')
+
+    # Create a hidden subdirectory with a file
+    hidden_subdir = test_dir / '.hidden_dir'
+    hidden_subdir.mkdir()
+    (hidden_subdir / 'file.txt').write_text('content3')
+
+    # View the directory
+    result = editor(command='view', path=str(test_dir))
+
+    # Verify output
+    assert isinstance(result, CLIResult)
+    assert str(test_dir) in result.output
+    assert 'visible.txt' in result.output  # Visible file is shown
+    assert '.hidden1' not in result.output  # Hidden files not shown
+    assert '.hidden2' not in result.output
+    assert '.hidden_dir' not in result.output
+    assert '3 hidden files/directories are excluded' in result.output  # Shows count of hidden items
+    assert 'ls -la' in result.output  # Shows command to view hidden files
 
 
 def test_view_symlinked_directory(tmp_path):

--- a/tests/integration/test_oh_editor.py
+++ b/tests/integration/test_oh_editor.py
@@ -401,6 +401,11 @@ def test_view_directory_with_hidden_files(tmp_path):
     hidden_subdir.mkdir()
     (hidden_subdir / 'file.txt').write_text('content3')
 
+    # Create a subdirectory with a hidden file
+    visible_subdir = test_dir / 'visible_dir'
+    visible_subdir.mkdir()
+    (visible_subdir / '.hidden_in_subdir').write_text('content4')
+
     # View the directory
     result = editor(command='view', path=str(test_dir))
 
@@ -408,12 +413,14 @@ def test_view_directory_with_hidden_files(tmp_path):
     assert isinstance(result, CLIResult)
     assert str(test_dir) in result.output
     assert 'visible.txt' in result.output  # Visible file is shown
+    assert 'visible_dir' in result.output  # Visible directory is shown
     assert '.hidden1' not in result.output  # Hidden files not shown
     assert '.hidden2' not in result.output
     assert '.hidden_dir' not in result.output
+    assert '.hidden_in_subdir' not in result.output  # Hidden file in visible dir not shown
     assert (
         '3 hidden files/directories are excluded' in result.output
-    )  # Shows count of hidden items
+    )  # Shows count of hidden items in current dir only
     assert 'ls -la' in result.output  # Shows command to view hidden files
 
 

--- a/tests/integration/test_oh_editor.py
+++ b/tests/integration/test_oh_editor.py
@@ -47,7 +47,9 @@ def test_view_directory(editor):
     assert str(test_file.parent) in result.output
     assert test_file.name in result.output
     assert 'excluding hidden items' in result.output
-    assert '0 hidden files/directories are excluded' not in result.output  # No message when no hidden files
+    assert (
+        '0 hidden files/directories are excluded' not in result.output
+    )  # No message when no hidden files
 
 
 def test_create_file(editor):
@@ -409,7 +411,9 @@ def test_view_directory_with_hidden_files(tmp_path):
     assert '.hidden1' not in result.output  # Hidden files not shown
     assert '.hidden2' not in result.output
     assert '.hidden_dir' not in result.output
-    assert '3 hidden files/directories are excluded' in result.output  # Shows count of hidden items
+    assert (
+        '3 hidden files/directories are excluded' in result.output
+    )  # Shows count of hidden items
     assert 'ls -la' in result.output  # Shows command to view hidden files
 
 

--- a/tests/integration/test_oh_editor.py
+++ b/tests/integration/test_oh_editor.py
@@ -401,10 +401,9 @@ def test_view_directory_with_hidden_files(tmp_path):
     hidden_subdir.mkdir()
     (hidden_subdir / 'file.txt').write_text('content3')
 
-    # Create a subdirectory with a hidden file
+    # Create a visible subdirectory
     visible_subdir = test_dir / 'visible_dir'
     visible_subdir.mkdir()
-    (visible_subdir / '.hidden_in_subdir').write_text('content4')
 
     # View the directory
     result = editor(command='view', path=str(test_dir))
@@ -418,10 +417,7 @@ def test_view_directory_with_hidden_files(tmp_path):
     assert '.hidden2' not in result.output
     assert '.hidden_dir' not in result.output
     assert (
-        '.hidden_in_subdir' not in result.output
-    )  # Hidden file in visible dir not shown
-    assert (
-        '3 hidden files/directories are excluded' in result.output
+        '3 hidden files/directories in this directory are excluded' in result.output
     )  # Shows count of hidden items in current dir only
     assert 'ls -la' in result.output  # Shows command to view hidden files
 


### PR DESCRIPTION
When using the `view` command on a directory, show how many hidden files/directories are excluded and provide instructions on how to view them using `ls -la`.

Fix https://github.com/All-Hands-AI/openhands-aci/issues/44