### PR TITLE
fix: suggested path is not really absolute

### DIFF
--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -334,7 +334,7 @@ class OHEditor:
         """
         # Check if its an absolute path
         if not path.is_absolute():
-            suggested_path = Path('') / path
+            suggested_path = Path.cwd() / path
             raise EditorToolParameterInvalidError(
                 'path',
                 path,

--- a/tests/integration/test_oh_editor.py
+++ b/tests/integration/test_oh_editor.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from openhands_aci.editor.editor import OHEditor
@@ -475,3 +477,15 @@ def test_view_large_file_with_truncation(editor, tmp_path):
     result = editor(command='view', path=str(large_file))
     assert isinstance(result, CLIResult)
     assert FILE_CONTENT_TRUNCATED_NOTICE in result.output
+
+
+def test_validate_path_suggests_absolute_path(editor):
+    editor, test_file = editor
+    relative_path = test_file.name  # This is a relative path
+    with pytest.raises(EditorToolParameterInvalidError) as exc_info:
+        editor(command='view', path=relative_path)
+    error_message = str(exc_info.value.message)
+    assert 'The path should be an absolute path' in error_message
+    assert 'Maybe you meant' in error_message
+    suggested_path = error_message.split('Maybe you meant ')[1].strip('?')
+    assert Path(suggested_path).is_absolute()


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

When the agent passes in relative path, the suggested path is still relative, when it should be absolute:

```
Invalid `path` parameter: openhands/storage/google_cloud.py. The path should be an absolute path, starting with `/`. Maybe you meant openhands/storage/google_cloud.py?
```
