### PR TITLE
Fix find command to only hide subpaths

### DIFF
--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -183,10 +183,9 @@ class OHEditor:
                 len(hidden_stdout.strip().split('\n')) if hidden_stdout.strip() else 0
             )
 
-            # Then get non-hidden files/dirs, excluding hidden files at all levels
-            # We need to exclude both files/dirs starting with . and files/dirs under hidden dirs
+            # Then get files/dirs up to 2 levels deep, excluding hidden entries at both depth 1 and 2
             _, stdout, stderr = run_shell_cmd(
-                rf"find -L {path} -maxdepth 2 -not -path '*/\.*' | sort",
+                rf"find -L {path} -maxdepth 2 -not \( -path '{path}/\.*' -o -path '{path}/*/\.*' \) | sort",
                 truncate_notice=DIRECTORY_CONTENT_TRUNCATED_NOTICE,
             )
             if not stderr:

--- a/tests/integration/test_oh_editor.py
+++ b/tests/integration/test_oh_editor.py
@@ -467,9 +467,9 @@ def test_view_large_directory_with_truncation(editor, tmp_path):
     assert DIRECTORY_CONTENT_TRUNCATED_NOTICE in result.output
 
 
-def test_view_directory_with_hidden_files_at_multiple_depths(tmp_path):
+def test_view_directory_on_hidden_path(tmp_path):
     """Directory structure:
-    test_dir/
+    .test_dir/
     ├── visible1.txt
     ├── .hidden1
     ├── visible_dir/
@@ -483,25 +483,25 @@ def test_view_directory_with_hidden_files_at_multiple_depths(tmp_path):
     editor = OHEditor()
 
     # Create a directory with test files at depth 1
-    test_dir = tmp_path / 'test_dir'
-    test_dir.mkdir()
-    (test_dir / 'visible1.txt').write_text('content1')
-    (test_dir / '.hidden1').write_text('hidden1')
+    hidden_test_dir = tmp_path / '.hidden_test_dir'
+    hidden_test_dir.mkdir()
+    (hidden_test_dir / 'visible1.txt').write_text('content1')
+    (hidden_test_dir / '.hidden1').write_text('hidden1')
 
     # Create a visible subdirectory with visible and hidden files
-    visible_subdir = test_dir / 'visible_dir'
+    visible_subdir = hidden_test_dir / 'visible_dir'
     visible_subdir.mkdir()
     (visible_subdir / 'visible2.txt').write_text('content2')
     (visible_subdir / '.hidden2').write_text('hidden2')
 
     # Create a hidden subdirectory with visible and hidden files
-    hidden_subdir = test_dir / '.hidden_dir'
+    hidden_subdir = hidden_test_dir / '.hidden_dir'
     hidden_subdir.mkdir()
     (hidden_subdir / 'visible3.txt').write_text('content3')
     (hidden_subdir / '.hidden3').write_text('hidden3')
 
     # View the directory
-    result = editor(command='view', path=str(test_dir))
+    result = editor(command='view', path=str(hidden_test_dir))
 
     # Verify output
     assert isinstance(result, CLIResult)

--- a/tests/integration/test_oh_editor.py
+++ b/tests/integration/test_oh_editor.py
@@ -467,6 +467,64 @@ def test_view_large_directory_with_truncation(editor, tmp_path):
     assert DIRECTORY_CONTENT_TRUNCATED_NOTICE in result.output
 
 
+def test_view_directory_with_hidden_files_at_multiple_depths(tmp_path):
+    """Directory structure:
+    test_dir/
+    ├── visible1.txt
+    ├── .hidden1
+    ├── visible_dir/
+    │   ├── visible2.txt
+    │   └── .hidden2
+    └── .hidden_dir/
+        ├── visible3.txt
+        └── .hidden3
+    """
+
+    editor = OHEditor()
+
+    # Create a directory with test files at depth 1
+    test_dir = tmp_path / 'test_dir'
+    test_dir.mkdir()
+    (test_dir / 'visible1.txt').write_text('content1')
+    (test_dir / '.hidden1').write_text('hidden1')
+
+    # Create a visible subdirectory with visible and hidden files
+    visible_subdir = test_dir / 'visible_dir'
+    visible_subdir.mkdir()
+    (visible_subdir / 'visible2.txt').write_text('content2')
+    (visible_subdir / '.hidden2').write_text('hidden2')
+
+    # Create a hidden subdirectory with visible and hidden files
+    hidden_subdir = test_dir / '.hidden_dir'
+    hidden_subdir.mkdir()
+    (hidden_subdir / 'visible3.txt').write_text('content3')
+    (hidden_subdir / '.hidden3').write_text('hidden3')
+
+    # View the directory
+    result = editor(command='view', path=str(test_dir))
+
+    # Verify output
+    assert isinstance(result, CLIResult)
+    # Depth 1: Visible files/dirs shown, hidden files/dirs not shown
+    assert 'visible1.txt' in result.output
+    assert 'visible_dir' in result.output
+    assert '.hidden1' not in result.output
+    assert '.hidden_dir' not in result.output
+
+    # Depth 2: Files in visible_dir shown
+    assert 'visible2.txt' in result.output
+    assert '.hidden2' not in result.output
+
+    # Depth 2: Files in hidden_dir not shown
+    assert 'visible3.txt' not in result.output
+    assert '.hidden3' not in result.output
+
+    # Hidden file count only includes depth 1
+    assert (
+        '2 hidden files/directories in this directory are excluded' in result.output
+    )  # Only .hidden1 and .hidden_dir at depth 1
+
+
 def test_view_large_file_with_truncation(editor, tmp_path):
     editor, _ = editor
     # Create a large file to trigger truncation


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This PR is to:
- Fix find command to only hide subpaths.

The command now is a bit cumbersome, I'm not able to figure out how to simplify it yet.

## Related Issue
<!--- Use the keywords 'Close', 'Closes', 'Fix', or 'Fixes' followed by the issue number(s) to close the related issue(s) -->

#44 
