### PR TITLE
Add trailing slash for folder paths when `view`ing directory

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -1,0 +1,32 @@
+name: Resolve Issue with OpenHands
+
+on:
+  issues:
+    types: [labeled]
+  pull_request:
+    types: [labeled]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  call-openhands-resolver:
+    uses: All-Hands-AI/OpenHands/.github/workflows/openhands-resolver.yml@main
+    with:
+      macro: ${{ vars.OPENHANDS_MACRO || '@openhands-agent' }}
+      max_iterations: ${{ fromJson(vars.OPENHANDS_MAX_ITER || 50) }}
+      base_container_image: ${{ vars.OPENHANDS_BASE_CONTAINER_IMAGE || '' }}
+      LLM_MODEL: ${{ vars.LLM_MODEL || 'anthropic/claude-3-5-sonnet-20241022' }}
+    secrets:
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+      PAT_USERNAME: ${{ secrets.PAT_USERNAME }}
+      LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+      LLM_BASE_URL: ${{ secrets.LLM_BASE_URL }}

--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -189,8 +189,18 @@ class OHEditor:
                 truncate_notice=DIRECTORY_CONTENT_TRUNCATED_NOTICE,
             )
             if not stderr:
+                # Add trailing slashes to directories
+                paths = stdout.strip().split('\n') if stdout.strip() else []
+                formatted_paths = []
+                for p in paths:
+                    if Path(p).is_dir():
+                        formatted_paths.append(f'{p}/')
+                    else:
+                        formatted_paths.append(p)
+
                 msg = [
-                    f"Here's the files and directories up to 2 levels deep in {path}, excluding hidden items:\n{stdout}"
+                    f"Here's the files and directories up to 2 levels deep in {path}, excluding hidden items:\n"
+                    + '\n'.join(formatted_paths)
                 ]
                 if hidden_count > 0:
                     msg.append(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openhands-aci"
-version = "0.1.8"
+version = "0.1.9"
 description = "An Agent-Computer Interface (ACI) designed for software development agents OpenHands."
 authors = ["OpenHands"]
 license = "MIT"

--- a/tests/integration/test_oh_editor.py
+++ b/tests/integration/test_oh_editor.py
@@ -44,14 +44,14 @@ def test_view_file(editor):
 
 def test_view_directory(editor):
     editor, test_file = editor
-    result = editor(command='view', path=str(test_file.parent))
-    assert isinstance(result, CLIResult)
-    assert str(test_file.parent) in result.output
-    assert test_file.name in result.output
-    assert 'excluding hidden items' in result.output
+    parent_dir = test_file.parent
+    result = editor(command='view', path=str(parent_dir))
     assert (
-        '0 hidden files/directories are excluded' not in result.output
-    )  # No message when no hidden files
+        result.output
+        == f"""Here's the files and directories up to 2 levels deep in {parent_dir}, excluding hidden items:
+{parent_dir}/
+{parent_dir}/test.txt"""
+    )
 
 
 def test_create_file(editor):


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This PR is to:
- Add trailing slash as a directory indicator for the `view` command

## Related Issue
<!--- Use the keywords 'Close', 'Closes', 'Fix', or 'Fixes' followed by the issue number(s) to close the related issue(s) -->

Close #54 
