### PR TITLE
Add repository documentation

### DIFF
--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -7,17 +7,6 @@ agent: CodeActAgent
 This repository contains the Agent-Computer Interface (ACI) for OpenHands, providing essential tools and interfaces for AI agents to interact with computer systems for software development tasks. The core functionality is implemented in Python and includes code editing, linting, and utility functions.
 
 ## General Setup:
-To set up the repository for development:
-
-1. Install dependencies using Poetry:
-```bash
-poetry install
-```
-
-2. Install pre-commit hooks:
-```bash
-make install-pre-commit-hooks
-```
 
 Before pushing any changes, ensure all checks pass:
 * Run pre-commit hooks: `pre-commit run --files openhands_aci/**/* tests/**/* --config ./dev_config/python/.pre-commit-config.yaml`

--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -1,0 +1,57 @@
+---
+name: repo
+type: repo
+agent: CodeActAgent
+---
+
+This repository contains the Agent-Computer Interface (ACI) for OpenHands, providing essential tools and interfaces for AI agents to interact with computer systems for software development tasks. The core functionality is implemented in Python and includes code editing, linting, and utility functions.
+
+## General Setup:
+To set up the repository for development:
+
+1. Install dependencies using Poetry:
+```bash
+poetry install
+```
+
+2. Install pre-commit hooks:
+```bash
+make install-pre-commit-hooks
+```
+
+Before pushing any changes, ensure all checks pass:
+* Run pre-commit hooks: `pre-commit run --files openhands_aci/**/* tests/**/* --config ./dev_config/python/.pre-commit-config.yaml`
+* Run tests: `poetry run pytest`
+
+The pre-commit hooks include:
+- Code formatting with Ruff
+- Type checking with MyPy
+- YAML validation
+- Trailing whitespace and EOF fixes
+- pyproject.toml validation and formatting
+
+## Repository Structure
+Core Code:
+- Located in the `openhands_aci` directory
+  - `editor/`: Code editing functionality
+  - `linter/`: Code linting capabilities (tree-sitter based)
+  - `utils/`: Utility functions (shell commands, diff generation, logging)
+
+Testing:
+- Located in the `tests` directory
+  - `tests/unit/`: Unit tests
+  - `tests/integration/`: Integration tests
+  - Run tests with: `poetry run pytest`
+
+Configuration:
+- `dev_config/python/`: Development configuration files
+  - `.pre-commit-config.yaml`: Pre-commit hook configuration
+  - `ruff.toml`: Ruff linter configuration
+  - `mypy.ini`: MyPy type checker configuration
+
+CI/CD:
+- GitHub Actions workflows in `.github/workflows/`
+  - `lint.yml`: Code linting checks
+  - `py-unit-tests.yml`: Unit tests
+  - `py-intg-tests.yml`: Integration tests
+  - `pypi-release.yml`: Package publishing to PyPI


### PR DESCRIPTION
This PR adds repository documentation in `.openhands/microagents/repo.md` that includes:

- Repository purpose and overview
- General setup instructions
- Repository structure details
- CI/CD and code quality requirements