### PR TITLE
fix: duplicate line numbers when `old_str` appears multiple times in a line

### DIFF
--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -146,7 +146,9 @@ class OHEditor:
                 f'No replacement was performed, old_str `{old_str}` did not appear verbatim in {path}.'
             )
         if len(occurrences) > 1:
-            line_numbers = [line for line, _, _ in occurrences]
+            line_numbers = list(
+                dict.fromkeys([line for line, _, _ in occurrences])
+            )  # Remove duplicate line numbers
             raise ToolError(
                 f'No replacement was performed. Multiple occurrences of old_str `{old_str}` in lines {line_numbers}. Please ensure it is unique.'
             )

--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -146,9 +146,7 @@ class OHEditor:
                 f'No replacement was performed, old_str `{old_str}` did not appear verbatim in {path}.'
             )
         if len(occurrences) > 1:
-            line_numbers = list(
-                dict.fromkeys([line for line, _, _ in occurrences])
-            )  # Remove duplicate line numbers
+            line_numbers = sorted(set(line for line, _, _ in occurrences))
             raise ToolError(
                 f'No replacement was performed. Multiple occurrences of old_str `{old_str}` in lines {line_numbers}. Please ensure it is unique.'
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openhands-aci"
-version = "0.2.0"
+version = "0.2.1"
 description = "An Agent-Computer Interface (ACI) designed for software development agents OpenHands."
 authors = ["OpenHands"]
 license = "MIT"

--- a/tests/integration/test_oh_editor.py
+++ b/tests/integration/test_oh_editor.py
@@ -216,7 +216,7 @@ def test_str_replace_nonexistent_string(editor):
     )
 
 
-def test_str_replace_with_empty_string(editor):
+def test_str_replace_with_empty_new_str(editor):
     editor, test_file = editor
     test_file.write_text('Line 1\nLine to remove\nLine 3')
     result = editor(
@@ -227,6 +227,22 @@ def test_str_replace_with_empty_string(editor):
     )
     assert isinstance(result, CLIResult)
     assert test_file.read_text() == 'Line 1\nLine 3'
+
+
+def test_str_replace_with_empty_old_str(editor):
+    editor, test_file = editor
+    test_file.write_text('Line 1\nLine 2\nLine 3')
+    with pytest.raises(ToolError) as exc_info:
+        editor(
+            command='str_replace',
+            path=str(test_file),
+            old_str='',
+            new_str='New string',
+        )
+    assert (
+        str(exc_info.value.message)
+        == """No replacement was performed. Multiple occurrences of old_str `` in lines [1, 2, 3]. Please ensure it is unique."""
+    )
 
 
 def test_str_replace_with_none_old_str(editor):


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

When `old_str` appears multiple times in a line, the current implementation also returns that line number multiple times in the error message. 

## Related Issue
<!--- Use the keywords 'Close', 'Closes', 'Fix', or 'Fixes' followed by the issue number(s) to close the related issue(s) -->

Fix #64 