### PR TITLE
Fix SQL file validation issue

### DIFF
--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -459,6 +459,9 @@ class OHEditor:
                 path=str(path),
                 reason='File appears to be binary. Only text files can be edited.',
             )
+        
+        # If the file is not binary, it's considered a valid text file
+        return
 
     def read_file(
         self,

--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -461,26 +461,13 @@ class OHEditor:
                 reason=f'File is too large ({file_size / 1024 / 1024:.1f}MB). Maximum allowed size is {int(max_size / 1024 / 1024)}MB.',
             )
 
-        # Check if file is binary
-        mime_type, _ = mimetypes.guess_type(str(path))
-        if mime_type is None:
-            # If mime_type is None, try to detect if it's binary by reading first chunk
-            try:
-                chunk = open(path, 'rb').read(1024)
-                if b'\0' in chunk:  # Common way to detect binary files
-                    raise FileValidationError(
-                        path=str(path),
-                        reason='File appears to be binary. Only text files can be edited.',
-                    )
-            except Exception as e:
-                raise FileValidationError(
-                    path=str(path), reason=f'Error checking file type: {str(e)}'
-                )
-        elif not mime_type.startswith('text/'):
-            # Known non-text mime type
+        # Check if file is binary using binaryornot
+        from binaryornot.check import is_binary
+
+        if is_binary(str(path)):
             raise FileValidationError(
                 path=str(path),
-                reason=f'File type {mime_type} is not supported. Only text files can be edited.',
+                reason='File appears to be binary. Only text files can be edited.',
             )
 
     def read_file(

--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -6,6 +6,7 @@ import tempfile
 from pathlib import Path
 from typing import Literal, get_args
 
+from binaryornot.check import is_binary
 from openhands_aci.linter import DefaultLinter
 from openhands_aci.utils.shell import run_shell_cmd
 
@@ -462,8 +463,6 @@ class OHEditor:
             )
 
         # Check if file is binary using binaryornot
-        from binaryornot.check import is_binary
-
         if is_binary(str(path)):
             raise FileValidationError(
                 path=str(path),

--- a/poetry.lock
+++ b/poetry.lock
@@ -180,6 +180,21 @@ tests = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4
 tests-mypy = ["mypy (>=1.11.1)", "pytest-mypy-plugins"]
 
 [[package]]
+name = "binaryornot"
+version = "0.4.4"
+description = "Ultra-lightweight pure Python package to check if a file is binary or text."
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "binaryornot-0.4.4-py2.py3-none-any.whl", hash = "sha256:b8b71173c917bddcd2c16070412e369c3ed7f0528926f70cac18a6c97fd563e4"},
+    {file = "binaryornot-0.4.4.tar.gz", hash = "sha256:359501dfc9d40632edc9fac890e19542db1a287bbcfa58175b66658392018061"},
+]
+
+[package.dependencies]
+chardet = ">=3.0.2"
+
+[[package]]
 name = "certifi"
 version = "2024.12.14"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -201,6 +216,18 @@ groups = ["dev"]
 files = [
     {file = "cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9"},
     {file = "cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560"},
+]
+
+[[package]]
+name = "chardet"
+version = "5.2.0"
+description = "Universal encoding detector for Python 3"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970"},
+    {file = "chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7"},
 ]
 
 [[package]]
@@ -2598,4 +2625,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "41094cd48ecc42806e42754c91c7481d4a41d23a22dbe66b02795a2d2bcc295f"
+content-hash = "36c5cd83fbf0767458907aad874e03defa6885c88492fd221e7181c501a31b7d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ grep-ast = "0.3.3"
 diskcache = "^5.6.3"
 flake8 = "*"
 whatthepatch = "^1.0.6"
+binaryornot = "^0.4.4"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/integration/editor/test_file_validation.py
+++ b/tests/integration/editor/test_file_validation.py
@@ -32,3 +32,21 @@ def test_file_validation(temp_file):
     result_json = parse_result(result)
     assert 'too large' in result_json['formatted_output_and_error']
     assert '10MB' in result_json['formatted_output_and_error']
+
+    # Test SQL file
+    sql_content = """
+    SELECT *
+    FROM users
+    WHERE id = 1;
+    """
+    with open(temp_file, 'w') as f:
+        f.write(sql_content)
+
+    result = file_editor(
+        command='view',
+        path=temp_file,
+        enable_linting=False,
+    )
+    result_json = parse_result(result)
+    assert 'SELECT *' in result_json['formatted_output_and_error']
+    assert 'binary' not in result_json['formatted_output_and_error'].lower()

--- a/tests/integration/editor/test_file_validation.py
+++ b/tests/integration/editor/test_file_validation.py
@@ -5,15 +5,22 @@ from openhands_aci.editor import file_editor
 from .conftest import parse_result
 
 
+import os
+from pathlib import Path
+
 def test_file_validation(temp_file):
     """Test file validation for various file types."""
+    # Ensure temp_file has .sql suffix
+    temp_file_sql = Path(temp_file).with_suffix('.sql')
+    os.rename(temp_file, temp_file_sql)
+
     # Test binary file
-    with open(temp_file, 'wb') as f:
+    with open(temp_file_sql, 'wb') as f:
         f.write(b'Some text\x00with binary\x00content')
 
     result = file_editor(
         command='view',
-        path=temp_file,
+        path=str(temp_file_sql),
         enable_linting=False,
     )
     result_json = parse_result(result)
@@ -21,12 +28,12 @@ def test_file_validation(temp_file):
 
     # Test large file
     large_size = 11 * 1024 * 1024  # 11MB
-    with open(temp_file, 'w') as f:
+    with open(temp_file_sql, 'w') as f:
         f.write('x' * large_size)
 
     result = file_editor(
         command='view',
-        path=temp_file,
+        path=str(temp_file_sql),
         enable_linting=False,
     )
     result_json = parse_result(result)
@@ -39,12 +46,12 @@ def test_file_validation(temp_file):
     FROM users
     WHERE id = 1;
     """
-    with open(temp_file, 'w') as f:
+    with open(temp_file_sql, 'w') as f:
         f.write(sql_content)
 
     result = file_editor(
         command='view',
-        path=temp_file,
+        path=str(temp_file_sql),
         enable_linting=False,
     )
     result_json = parse_result(result)


### PR DESCRIPTION
This PR fixes the issue with SQL file validation by using the binaryornot library instead of mimetypes. It also adds a test to ensure SQL files can be edited.