### PR TITLE
Fix the editor read file bubbling a non-tool error

### DIFF
--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -579,8 +579,8 @@ class OHEditor:
             end_line: Optional end line number (1-based). Must be provided with start_line.
             encoding: The encoding to use when reading the file (auto-detected by decorator)
         """
-        self.validate_file(path)
         try:
+            self.validate_file(path)
             if start_line is not None and end_line is not None:
                 # Read only the specified line range
                 lines = []
@@ -599,6 +599,8 @@ class OHEditor:
                 # Use line-by-line reading to avoid loading entire file into memory
                 with open(path, 'r', encoding=encoding) as f:
                     return ''.join(f)
+        except ToolError:
+            raise
         except Exception as e:
             raise ToolError(f'Ran into {e} while trying to read {path}') from None
 


### PR DESCRIPTION
## Description
We were processing some PDF files and when the agent tried to read the PDF, there was an uncaught exception that halted the agent state.

It's expected that `read_file` only raise ToolError, but the validate and call into is_binary library can raise other errors.

## Related Issue
<!--- Use the keywords 'Close', 'Closes', 'Fix', or 'Fixes' followed by the issue number(s) to close the related issue(s) -->

## Motivation and Context
Make sure `read_file` only throw tool error
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Verified on our fork on the problematic PDFs.
<!--- Please describe in detail how you tested your changes. -->

## Does this PR introduce a breaking change?
No, this makes the current read file tool adhere to the spec more completely.
<!--- If this PR introduces a breaking change, please describe the impact and migration path for existing applications below. -->
