### PR TITLE
fix: incorrect line number in output snippet for `str_replace` and `insert`

### DIFF
--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -216,7 +216,7 @@ class OHEditor:
         end_line = replacement_line + SNIPPET_CONTEXT_WINDOW + new_str.count('\n')
 
         # Read just the snippet range
-        snippet = self.read_file(path, start_line=start_line, end_line=end_line)
+        snippet = self.read_file(path, start_line=start_line + 1, end_line=end_line)
 
         # Prepare the success message
         success_message = f'The file {path} has been edited. '
@@ -428,12 +428,12 @@ class OHEditor:
         shutil.move(temp_file.name, path)
 
         # Read just the snippet range
-        start_line = max(1, insert_line - SNIPPET_CONTEXT_WINDOW)
+        start_line = max(0, insert_line - SNIPPET_CONTEXT_WINDOW)
         end_line = min(
             num_lines + len(new_str_lines),
             insert_line + SNIPPET_CONTEXT_WINDOW + len(new_str_lines),
         )
-        snippet = self.read_file(path, start_line=start_line, end_line=end_line)
+        snippet = self.read_file(path, start_line=start_line + 1, end_line=end_line + 1)
 
         # Save history - we already have the lines in memory
         file_text = ''.join(history_lines)

--- a/tests/integration/test_oh_editor.py
+++ b/tests/integration/test_oh_editor.py
@@ -100,6 +100,7 @@ def test_str_replace_no_linting(editor):
      2\tThis file is for testing purposes.
 Review the changes and make sure they are as expected. Edit the file again if necessary."""
     )
+    print(result.output)
 
     # Test that the file content has been updated
     assert 'This is a sample file.' in test_file.read_text()
@@ -605,3 +606,49 @@ def test_validate_path_suggests_absolute_path(editor, tmp_path):
     suggested_path = error_message.split('Maybe you meant ')[1].strip('?')
     assert Path(suggested_path).is_absolute()
     assert str(test_file.parent) in suggested_path
+
+
+def test_str_replace_and_insert_snippet_output_on_a_large_file(editor):
+    editor, test_file = editor
+
+    # Replace the current content with content: Line {line_number}
+    _ = editor(
+        command='str_replace',
+        path=str(test_file),
+        old_str='This is a test file.\nThis file is for testing purposes.',
+        new_str='',
+    )
+    for i in range(0, 700):
+        _ = editor(
+            command='insert', path=str(test_file), insert_line=i, new_str=f'Line {i+1}'
+        )
+
+    # View file
+    result = editor(command='view', path=str(test_file))
+    assert '     1\tLine 1' in result.output
+    assert '   500\tLine 500' in result.output
+
+    # Replace line 500's content with '500 new'
+    result = editor(
+        command='str_replace',
+        path=str(test_file),
+        old_str='Line 500',
+        new_str='500 new',
+    )
+    assert '   500\t500 new' in result.output
+
+    # Delete the line '500 new'
+    result = editor(
+        command='str_replace', path=str(test_file), old_str='500 new\n', new_str=''
+    )
+    assert '   499\tLine 499' in result.output
+    assert '   500\tLine 501' in result.output
+
+    # Insert content at line 500
+    result = editor(
+        command='insert',
+        path=str(test_file),
+        insert_line=499,
+        new_str='Inserted line at 500',
+    )
+    assert '   500\tInserted line at 500' in result.output


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Currently, we don't have tests for editing commands on large files (where outputs will be just a snippet in the 4-line window) so we didn't catch this error previously. I investigated a bit and it seems in an old PR to reduce memory consumption, we (and OpenHands) messed up with the line numbers, as some places they are 0-based and in other places they are 1-based.

## Related Issue
<!--- Use the keywords 'Close', 'Closes', 'Fix', or 'Fixes' followed by the issue number(s) to close the related issue(s) -->

https://github.com/All-Hands-AI/OpenHands/issues/7724