### PR TITLE
fix: extra new line when using `view` command with `view_range`

### DIFF
--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -335,7 +335,9 @@ class OHEditor:
         file_content = self.read_file(path, start_line=start_line, end_line=end_line)
 
         # Get the detected encoding
-        output = self._make_output(file_content, str(path), start_line)
+        output = self._make_output(
+            '\n'.join(file_content.splitlines()), str(path), start_line
+        )  # Remove extra newlines
 
         return CLIResult(
             path=str(path),
@@ -618,7 +620,7 @@ class OHEditor:
         snippet_content = '\n'.join(
             [
                 f'{i + start_line:6}\t{line}'
-                for i, line in enumerate(snippet_content.splitlines())
+                for i, line in enumerate(snippet_content.split('\n'))
             ]
         )
         return (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openhands-aci"
-version = "0.2.9"
+version = "0.2.10"
 description = "An Agent-Computer Interface (ACI) designed for software development agents OpenHands."
 authors = ["OpenHands"]
 license = "MIT"

--- a/tests/integration/editor/test_basic_operations.py
+++ b/tests/integration/editor/test_basic_operations.py
@@ -102,6 +102,7 @@ match = re.search(
      5\t    re.DOTALL,
      6\t)
      7\t...More text here.
+     8\t
 """
     )
 

--- a/tests/integration/test_oh_editor.py
+++ b/tests/integration/test_oh_editor.py
@@ -76,7 +76,7 @@ def test_view_with_a_specific_range(editor):
     assert '    49\tLine 49' not in result.output
     assert '    50\tLine 50' in result.output
     assert '   100\tLine 100' in result.output
-    assert '   101' not in result.output
+    assert '101' not in result.output
 
 
 def test_create_file(editor):

--- a/tests/integration/test_oh_editor.py
+++ b/tests/integration/test_oh_editor.py
@@ -40,6 +40,7 @@ def test_view_file(editor):
     assert f"Here's the result of running `cat -n` on {test_file}:" in result.output
     assert '1\tThis is a test file.' in result.output
     assert '2\tThis file is for testing purposes.' in result.output
+    assert '3\t' not in result.output  # No extra line
 
 
 def test_view_directory(editor):
@@ -52,6 +53,30 @@ def test_view_directory(editor):
 {parent_dir}/
 {parent_dir}/test.txt"""
     )
+
+
+def test_view_with_a_specific_range(editor):
+    editor, test_file = editor
+
+    # Replace the current content with content: Line {line_number}
+    _ = editor(
+        command='str_replace',
+        path=str(test_file),
+        old_str='This is a test file.\nThis file is for testing purposes.',
+        new_str='',
+    )
+    for i in range(0, 200):
+        _ = editor(
+            command='insert', path=str(test_file), insert_line=i, new_str=f'Line {i+1}'
+        )
+
+    # View file in range 50-100
+    result = editor(command='view', path=str(test_file), view_range=[50, 100])
+    assert f"Here's the result of running `cat -n` on {test_file}:" in result.output
+    assert '    49\tLine 49' not in result.output
+    assert '    50\tLine 50' in result.output
+    assert '   100\tLine 100' in result.output
+    assert '   101' not in result.output
 
 
 def test_create_file(editor):
@@ -72,6 +97,11 @@ def test_create_with_empty_string(editor):
     assert new_file.exists()
     assert new_file.read_text() == ''
     assert 'File created successfully' in result.output
+
+    # Test the view command showing an empty line
+    result = editor(command='view', path=str(new_file))
+    assert f"Here's the result of running `cat -n` on {new_file}:" in result.output
+    assert '1\t' in result.output  # Check for empty line
 
 
 def test_create_with_none_file_text(editor):
@@ -100,7 +130,6 @@ def test_str_replace_no_linting(editor):
      2\tThis file is for testing purposes.
 Review the changes and make sure they are as expected. Edit the file again if necessary."""
     )
-    print(result.output)
 
     # Test that the file content has been updated
     assert 'This is a sample file.' in test_file.read_text()
@@ -265,7 +294,6 @@ def test_insert_no_linting(editor):
     )
     assert isinstance(result, CLIResult)
     assert 'Inserted line' in test_file.read_text()
-    print(result.output)
     assert (
         result.output
         == f"""The file {test_file} has been edited. Here's the result of running `cat -n` on a snippet of the edited file:
@@ -287,7 +315,6 @@ def test_insert_with_linting(editor):
     )
     assert isinstance(result, CLIResult)
     assert 'Inserted line' in test_file.read_text()
-    print(result.output)
     assert (
         result.output
         == f"""The file {test_file} has been edited. Here's the result of running `cat -n` on a snippet of the edited file:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

In the current implementation, when using the `view` command with `view_range`, there's an extra empty line being printed after the `end` line. This PR fixes that error and adds a test for it.

This seems to be another bug that we didn't catch, as we changed our implementation compared to Anthropic's original implementation. Their implementation avoids this by calling a `split("\n")` and then `join` in the specified range:

https://github.com/anthropics/anthropic-quickstarts/blob/1ee478a2c27be77e8ea70d860d8cddb9b4d5fcb9/computer-use-demo/computer_use_demo/tools/edit.py#L129-L148 

