### PR TITLE
Remove tab normalization for the editor

### DIFF
--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -164,11 +164,10 @@ class OHEditor:
             encoding: The encoding to use (auto-detected by decorator)
         """
         self.validate_file(path)
-        old_str = old_str.expandtabs()
-        new_str = new_str.expandtabs() if new_str is not None else ''
+        new_str = new_str or ''
 
         # Read the entire file first to handle both single-line and multi-line replacements
-        file_content = self.read_file(path).expandtabs()
+        file_content = self.read_file(path)
 
         # Find all occurrences using regex
         # Escape special regex characters in old_str to match it literally
@@ -393,7 +392,6 @@ class OHEditor:
                 f'It should be within the range of lines of the file: {[0, num_lines]}',
             )
 
-        new_str = new_str.expandtabs()
         new_str_lines = new_str.split('\n')
 
         # Create temporary file for the new content
@@ -406,7 +404,7 @@ class OHEditor:
                 for i, line in enumerate(f, 1):
                     if i > insert_line:
                         break
-                    temp_file.write(line.expandtabs())
+                    temp_file.write(line)
                     history_lines.append(line)
 
             # Insert new content
@@ -418,7 +416,7 @@ class OHEditor:
                 for i, line in enumerate(f, 1):
                     if i <= insert_line:
                         continue
-                    temp_file.write(line.expandtabs())
+                    temp_file.write(line)
                     history_lines.append(line)
 
         # Move temporary file to original location
@@ -510,7 +508,7 @@ class OHEditor:
         """
         Implement the undo_edit command.
         """
-        current_text = self.read_file(path).expandtabs()
+        current_text = self.read_file(path)
         old_text = self._history_manager.pop_last_history(path)
         if old_text is None:
             raise ToolError(f'No edit history found for {path}.')
@@ -606,7 +604,6 @@ class OHEditor:
         snippet_content: str,
         snippet_description: str,
         start_line: int = 1,
-        expand_tabs: bool = True,
     ) -> str:
         """
         Generate output for the CLI based on the content of a code snippet.
@@ -614,8 +611,6 @@ class OHEditor:
         snippet_content = maybe_truncate(
             snippet_content, truncate_notice=FILE_CONTENT_TRUNCATED_NOTICE
         )
-        if expand_tabs:
-            snippet_content = snippet_content.expandtabs()
 
         snippet_content = '\n'.join(
             [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openhands-aci"
-version = "0.2.10"
+version = "0.2.11"
 description = "An Agent-Computer Interface (ACI) designed for software development agents OpenHands."
 authors = ["OpenHands"]
 license = "MIT"

--- a/tests/integration/editor/test_basic_operations.py
+++ b/tests/integration/editor/test_basic_operations.py
@@ -176,8 +176,8 @@ def test_tab_expansion(temp_file):
     )
     result_json = parse_result(result)
     # Tabs should be expanded to spaces in output
-    assert '    indented' in result_json['formatted_output_and_error']
-    assert 'line    with    tabs' in result_json['formatted_output_and_error']
+    assert '\tindented' in result_json['formatted_output_and_error']
+    assert 'line\twith\ttabs' in result_json['formatted_output_and_error']
 
     # Test str_replace with tabs in old_str
     result = file_editor(
@@ -200,7 +200,7 @@ def test_tab_expansion(temp_file):
     )
     result_json = parse_result(result)
     # Tabs should be expanded in the output
-    assert 'new     line    with    tabs' in result_json['formatted_output_and_error']
+    assert 'new\tline\twith\ttabs' in result_json['formatted_output_and_error']
 
     # Test insert with tabs
     result = file_editor(
@@ -212,4 +212,4 @@ def test_tab_expansion(temp_file):
     )
     result_json = parse_result(result)
     # Tabs should be expanded in the output
-    assert '        indented        line' in result_json['formatted_output_and_error']
+    assert '\tindented\tline' in result_json['formatted_output_and_error']

--- a/tests/integration/test_oh_editor.py
+++ b/tests/integration/test_oh_editor.py
@@ -169,7 +169,7 @@ def test_str_replace_multi_line_with_tabs_no_linting(editor_python_file_with_tab
         result.output
         == f"""The file {test_file} has been edited. Here's the result of running `cat -n` on a snippet of {test_file}:
      1\tdef test():
-     2\t{'\t'.expandtabs()}print("Hello, Universe!")
+     2\t\tprint("Hello, Universe!")
 Review the changes and make sure they are as expected. Edit the file again if necessary."""
     )
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Currently the editor replaces tabs in the original file content with spaces when creating observations for the agent as well as writing new content to files. This is originally from [Anthropic's implementation](https://github.com/anthropics/anthropic-quickstarts/blob/main/computer-use-demo/computer_use_demo/tools/edit.py), but it seems to be problematic in scenarios where tab-based indentation is important, e.g. Makefiles,...

- I gave this branch a try in OH and the agent seems to be able to edit and use the modified Makefile.
- Running an eval on 100 instances, the agent doesn't seem to have difficulties to I think it's safe to merge: 
  - This PR: `58/100`
  - main: `60/100`

## Related Issue
<!--- Use the keywords 'Close', 'Closes', 'Fix', or 'Fixes' followed by the issue number(s) to close the related issue(s) -->

https://github.com/All-Hands-AI/OpenHands/issues/6160
