### PR TITLE
Tweak error message for insert_line

### DIFF
--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -389,7 +389,7 @@ class OHEditor:
             raise EditorToolParameterInvalidError(
                 'insert_line',
                 insert_line,
-                f'It should be within the range of lines of the file: {[0, num_lines]}',
+                f'It should be within the range of allowed values: {[0, num_lines]}',
             )
 
         new_str_lines = new_str.split('\n')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openhands-aci"
-version = "0.2.12"
+version = "0.2.13"
 description = "An Agent-Computer Interface (ACI) designed for software development agents OpenHands."
 authors = ["OpenHands"]
 license = "MIT"

--- a/tests/integration/test_oh_editor.py
+++ b/tests/integration/test_oh_editor.py
@@ -337,7 +337,7 @@ def test_insert_invalid_line(editor):
             new_str='Invalid Insert',
         )
     assert 'Invalid `insert_line` parameter' in str(exc_info.value.message)
-    assert 'It should be within the range of lines of the file' in str(
+    assert 'It should be within the range of allowed values:' in str(
         exc_info.value.message
     )
 


### PR DESCRIPTION
Tweak error message for the wrong `insert_line` parameter for `str_replace_editor` `insert` command, to try to avoid suggesting to the LLM that it's exactly a line.

Issue stems from confusing LLMs like this:

> Let's re-read the error: "It should be within the range of lines of the file: [0, 110]". This sounds like line numbers are 0-indexed for insert_line in the API, but 1-indexed in view_range and cat -n.
> If cat -n shows 111 lines, then 0-indexed lines are 0 to 110.
> If I want to insert after the current last line (line 110 in 0-indexed, which is line 111 in 1-indexed cat -n output), I should use insert_line = 110.

The change proposed here and on the [tool description](https://github.com/All-Hands-AI/OpenHands/pull/8434) are in testing.

Reference [slack discussion](https://openhands-ai.slack.com/archives/C06R25BT5B2/p1746888159415999)

