### PR TITLE
Add JSON logger support

### DIFF
--- a/openhands_aci/utils/logger.py
+++ b/openhands_aci/utils/logger.py
@@ -1,7 +1,13 @@
+import json
 import logging
 import os
+import time
+from typing import Any, Dict, Optional
 
 LOG_LEVEL = os.getenv('LOG_LEVEL', 'INFO').upper()
+# Check if LOG_JSON is explicitly set to true, otherwise default to False
+LOG_JSON_ENV = os.getenv('LOG_JSON', 'False')
+LOG_JSON = LOG_JSON_ENV.lower() in ['true', '1', 'yes'] if LOG_JSON_ENV else False
 
 DEBUG = os.getenv('DEBUG', 'False').lower() in ['true', '1', 'yes']
 if DEBUG:
@@ -13,13 +19,59 @@ current_log_level = logging.INFO
 if LOG_LEVEL in logging.getLevelNamesMapping():
     current_log_level = logging.getLevelNamesMapping()[LOG_LEVEL]
 
+
+class JSONFormatter(logging.Formatter):
+    """
+    Formatter that outputs JSON strings after parsing the log record.
+    """
+    def __init__(self, fmt_dict: Optional[Dict[str, Any]] = None):
+        """
+        Initialize the formatter with the specified format dictionary.
+        """
+        super().__init__()
+        self.fmt_dict = fmt_dict if fmt_dict else {}
+
+    def format(self, record: logging.LogRecord) -> str:
+        """
+        Format the specified record as JSON.
+        """
+        record_dict = {
+            'timestamp': int(time.time() * 1000),
+            'time': self.formatTime(record, datefmt='%Y-%m-%d %H:%M:%S'),
+            'name': record.name,
+            'level': record.levelname,
+            'message': record.getMessage(),
+        }
+
+        if record.exc_info:
+            record_dict['exc_info'] = self.formatException(record.exc_info)
+
+        if hasattr(record, 'stack_info') and record.stack_info:
+            record_dict['stack_info'] = self.formatStack(record.stack_info)
+
+        # Add custom fields from the record
+        for key, value in self.fmt_dict.items():
+            if key == 'asctime':
+                # Already handled above
+                continue
+            if hasattr(record, key):
+                record_dict[key] = getattr(record, key)
+
+        return json.dumps(record_dict)
+
+
 console_handler = logging.StreamHandler()
 console_handler.setLevel(current_log_level)
-formatter = logging.Formatter(
-    '{asctime} - {name}:{levelname} - {message}',
-    style='{',
-    datefmt='%Y-%m-%d %H:%M',
-)
+
+if LOG_JSON:
+    formatter = JSONFormatter()
+else:
+    formatter = logging.Formatter(
+        '{asctime} - {name}:{levelname} - {message}',
+        style='{',
+        datefmt='%Y-%m-%d %H:%M',
+    )
+
 console_handler.setFormatter(formatter)
 
 oh_aci_logger.setLevel(current_log_level)

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -1,0 +1,79 @@
+import json
+import logging
+import os
+from io import StringIO
+from unittest import mock
+
+import pytest
+
+from openhands_aci.utils.logger import JSONFormatter, oh_aci_logger
+
+
+class TestLogger:
+    def test_json_formatter(self):
+        """Test that JSONFormatter correctly formats log records as JSON."""
+        formatter = JSONFormatter()
+        record = logging.LogRecord(
+            name="test_logger",
+            level=logging.INFO,
+            pathname="test_path",
+            lineno=42,
+            msg="Test message",
+            args=(),
+            exc_info=None,
+        )
+
+        formatted = formatter.format(record)
+        parsed = json.loads(formatted)
+
+        assert parsed["name"] == "test_logger"
+        assert parsed["level"] == "INFO"
+        assert parsed["message"] == "Test message"
+        assert "timestamp" in parsed
+        assert "time" in parsed
+
+    @mock.patch.dict(os.environ, {"LOG_JSON": "true"})
+    def test_json_logging_enabled(self):
+        """Test that JSON logging is enabled when LOG_JSON=true."""
+        # We need to reload the logger module to apply the environment variable
+        with mock.patch("sys.stdout", new=StringIO()) as fake_out:
+            # Create a new logger with the same name to test
+            test_logger = logging.getLogger("test_json_logger")
+            test_logger.setLevel(logging.INFO)
+            
+            # Create a handler that writes to our StringIO
+            handler = logging.StreamHandler(fake_out)
+            
+            # Use the JSONFormatter
+            formatter = JSONFormatter()
+            handler.setFormatter(formatter)
+            
+            test_logger.addHandler(handler)
+            test_logger.propagate = False
+            
+            # Log a message
+            test_logger.info("Test JSON logging")
+            
+            # Get the output
+            output = fake_out.getvalue().strip()
+            
+            # Verify it's valid JSON
+            parsed = json.loads(output)
+            assert parsed["name"] == "test_json_logger"
+            assert parsed["level"] == "INFO"
+            assert parsed["message"] == "Test JSON logging"
+
+    def test_logger_initialization(self):
+        """Test that the logger is properly initialized."""
+        assert oh_aci_logger.name == "openhands_aci"
+        assert len(oh_aci_logger.handlers) > 0
+        
+        # Check that the handler is a StreamHandler
+        handler = oh_aci_logger.handlers[0]
+        assert isinstance(handler, logging.StreamHandler)
+        
+        # Check formatter type based on LOG_JSON environment variable
+        if os.environ.get("LOG_JSON", "").lower() in ["true", "1", "yes"]:
+            assert isinstance(handler.formatter, JSONFormatter)
+        else:
+            assert isinstance(handler.formatter, logging.Formatter)


### PR DESCRIPTION
## Description

This PR adds support for JSON logging when LOG_JSON environment variable is set to true.

## Related Issue

Fixes #120

## Motivation and Context

In OpenHands, setting LOG_JSON=true enables JSON logging output. However, the openhands-aci logs do not support this format.

## How Has This Been Tested?

Added unit tests for the JSON formatter and manually tested with LOG_JSON=true/false.

## Does this PR introduce a breaking change?

No.