### PR TITLE
Fix issue #140: Suppress pydub warnings when ffmpeg is not available

### DIFF
--- a/openhands_aci/editor/md_converter.py
+++ b/openhands_aci/editor/md_converter.py
@@ -36,11 +36,13 @@ pydub_available = False
 try:
     # Temporarily suppress warnings during import
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+        warnings.simplefilter('ignore')
         import pydub
+
         # Check if ffmpeg or avconv is available
         from pydub.utils import which
-        if which("ffmpeg") or which("avconv"):
+
+        if which('ffmpeg') or which('avconv'):
             pydub_available = True
 except (ImportError, RuntimeError):
     pass
@@ -792,7 +794,7 @@ class Mp3Converter(WavConverter):
         try:
             # Use pydub with warnings suppressed
             with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
+                warnings.simplefilter('ignore')
                 sound = pydub.AudioSegment.from_mp3(local_path)
                 sound.export(temp_path, format='wav')
 

--- a/openhands_aci/editor/md_converter.py
+++ b/openhands_aci/editor/md_converter.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import tempfile
 import traceback
+import warnings
 from typing import Any, Dict, List, Optional, Union
 from urllib.parse import parse_qs, quote, unquote, urlparse, urlunparse
 
@@ -23,12 +24,26 @@ import pptx
 
 # File-format detection
 import puremagic
-import pydub
 import requests
 import speech_recognition as sr
 from bs4 import BeautifulSoup
 from youtube_transcript_api import YouTubeTranscriptApi
 from youtube_transcript_api.formatters import SRTFormatter
+
+# Conditionally import pydub and check for ffmpeg availability
+pydub = None
+pydub_available = False
+try:
+    # Temporarily suppress warnings during import
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        import pydub
+        # Check if ffmpeg or avconv is available
+        from pydub.utils import which
+        if which("ffmpeg") or which("avconv"):
+            pydub_available = True
+except (ImportError, RuntimeError):
+    pass
 
 
 class _CustomMarkdownify(markdownify.MarkdownConverter):
@@ -763,12 +778,23 @@ class Mp3Converter(WavConverter):
                 if f in metadata:
                     md_content += f'{f}: {metadata[f]}\n'
 
+        # Check if pydub is available with ffmpeg/avconv
+        if not pydub_available or pydub is None:
+            md_content += '\n\n### Audio Transcript:\nTranscription unavailable - ffmpeg/avconv not installed.'
+            return DocumentConverterResult(
+                title=os.path.basename(local_path),
+                text_content=md_content,
+            )
+
         # Transcribe
         handle, temp_path = tempfile.mkstemp(suffix='.wav')
         os.close(handle)
         try:
-            sound = pydub.AudioSegment.from_mp3(local_path)
-            sound.export(temp_path, format='wav')
+            # Use pydub with warnings suppressed
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                sound = pydub.AudioSegment.from_mp3(local_path)
+                sound.export(temp_path, format='wav')
 
             _args = dict()
             _args.update(kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openhands-aci"
-version = "0.3.0"
+version = "0.3.1"
 description = "An Agent-Computer Interface (ACI) designed for software development agents OpenHands."
 authors = ["OpenHands"]
 license = "MIT"

--- a/tests/unit/editor/test_md_converter.py
+++ b/tests/unit/editor/test_md_converter.py
@@ -1,11 +1,8 @@
-import os
 import tempfile
 import unittest
 from unittest import mock
 
-import pytest
-
-from openhands_aci.editor.md_converter import Mp3Converter, pydub_available
+from openhands_aci.editor.md_converter import Mp3Converter
 
 
 class TestMp3Converter(unittest.TestCase):
@@ -14,29 +11,35 @@ class TestMp3Converter(unittest.TestCase):
     def test_pydub_not_available(self):
         """Test that Mp3Converter handles the case when pydub is not available."""
         # Mock the pydub_available flag to be False
-        with mock.patch("openhands_aci.editor.md_converter.pydub_available", False):
+        with mock.patch('openhands_aci.editor.md_converter.pydub_available', False):
             converter = Mp3Converter()
-            
+
             # Create a temporary file with .mp3 extension
-            with tempfile.NamedTemporaryFile(suffix=".mp3") as temp_file:
+            with tempfile.NamedTemporaryFile(suffix='.mp3') as temp_file:
                 # Call convert method
-                result = converter.convert(temp_file.name, file_extension=".mp3")
-                
+                result = converter.convert(temp_file.name, file_extension='.mp3')
+
                 # Check that the result contains the expected message
                 assert result is not None
-                assert "Transcription unavailable - ffmpeg/avconv not installed" in result.text_content
+                assert (
+                    'Transcription unavailable - ffmpeg/avconv not installed'
+                    in result.text_content
+                )
 
     def test_pydub_none(self):
         """Test that Mp3Converter handles the case when pydub is None."""
         # Mock pydub to be None
-        with mock.patch("openhands_aci.editor.md_converter.pydub", None):
+        with mock.patch('openhands_aci.editor.md_converter.pydub', None):
             converter = Mp3Converter()
-            
+
             # Create a temporary file with .mp3 extension
-            with tempfile.NamedTemporaryFile(suffix=".mp3") as temp_file:
+            with tempfile.NamedTemporaryFile(suffix='.mp3') as temp_file:
                 # Call convert method
-                result = converter.convert(temp_file.name, file_extension=".mp3")
-                
+                result = converter.convert(temp_file.name, file_extension='.mp3')
+
                 # Check that the result contains the expected message
                 assert result is not None
-                assert "Transcription unavailable - ffmpeg/avconv not installed" in result.text_content
+                assert (
+                    'Transcription unavailable - ffmpeg/avconv not installed'
+                    in result.text_content
+                )

--- a/tests/unit/editor/test_md_converter.py
+++ b/tests/unit/editor/test_md_converter.py
@@ -1,0 +1,42 @@
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+import pytest
+
+from openhands_aci.editor.md_converter import Mp3Converter, pydub_available
+
+
+class TestMp3Converter(unittest.TestCase):
+    """Test the Mp3Converter class."""
+
+    def test_pydub_not_available(self):
+        """Test that Mp3Converter handles the case when pydub is not available."""
+        # Mock the pydub_available flag to be False
+        with mock.patch("openhands_aci.editor.md_converter.pydub_available", False):
+            converter = Mp3Converter()
+            
+            # Create a temporary file with .mp3 extension
+            with tempfile.NamedTemporaryFile(suffix=".mp3") as temp_file:
+                # Call convert method
+                result = converter.convert(temp_file.name, file_extension=".mp3")
+                
+                # Check that the result contains the expected message
+                assert result is not None
+                assert "Transcription unavailable - ffmpeg/avconv not installed" in result.text_content
+
+    def test_pydub_none(self):
+        """Test that Mp3Converter handles the case when pydub is None."""
+        # Mock pydub to be None
+        with mock.patch("openhands_aci.editor.md_converter.pydub", None):
+            converter = Mp3Converter()
+            
+            # Create a temporary file with .mp3 extension
+            with tempfile.NamedTemporaryFile(suffix=".mp3") as temp_file:
+                # Call convert method
+                result = converter.convert(temp_file.name, file_extension=".mp3")
+                
+                # Check that the result contains the expected message
+                assert result is not None
+                assert "Transcription unavailable - ffmpeg/avconv not installed" in result.text_content


### PR DESCRIPTION
This PR fixes issue #140 by suppressing pydub warnings when ffmpeg is not available.

## Changes:
1. Added conditional import for pydub that checks if ffmpeg or avconv is available
2. Modified Mp3Converter to check for pydub availability before attempting to use it
3. Added unit tests to verify the fix

## Testing:
- Added unit tests that verify the Mp3Converter handles the case when pydub is not available or ffmpeg is not installed
- All unit tests pass

Fixes #140

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f156b5f1d9d34f668ccccffa89575cff)