### PR TITLE
Strip whitespace if no occurences found str_replace

### DIFF
--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -204,9 +204,23 @@ class OHEditor:
         ]
 
         if not occurrences:
-            raise ToolError(
-                f'No replacement was performed, old_str `{old_str}` did not appear verbatim in {path}.'
-            )
+            # We found no occurrences, possibly because of extra white spaces at either the front or back of the string.
+            # Remove the white spaces and try again.
+            old_str = old_str.strip()
+            new_str = new_str.strip()
+            pattern = re.escape(old_str)
+            occurrences = [
+                (
+                    file_content.count('\n', 0, match.start()) + 1,  # line number
+                    match.group(),  # matched text
+                    match.start(),  # start position
+                )
+                for match in re.finditer(pattern, file_content)
+            ]
+            if not occurrences:
+                raise ToolError(
+                    f'No replacement was performed, old_str `{old_str}` did not appear verbatim in {path}.'
+                )
         if len(occurrences) > 1:
             line_numbers = sorted(set(line for line, _, _ in occurrences))
             raise ToolError(


### PR DESCRIPTION
Helps reduce the amount of retries when using an LLM like Devstral.

## Description
This change tries the original str_replace code. If no occurrences are found we fallback to a code path which strips both old_str and new_str and then tries to match them again. 

## Related Issue
Fixes https://github.com/All-Hands-AI/OpenHands/issues/8958

## Motivation and Context
I found that str_replace would often fail when using Devstral. Most of the time the issue is caused by an additional leading newline character. This causes the model to get stuck often repeating str_replace with slightly different strings. Without ever learning that the reason it couldn't find a match is because of an additional newline. 

Devstral seems particularly problematic. But I've seen the same issue when using Claude 4 Sonnet or when running in OpenHands Cloud.

## How Has This Been Tested?
Just using OpenHands I waited for the problem to occur and then recorded the file and action description. I had 4 examples total. I then added a test in which it creates a temp copy of the original file and tries to perform the action in a modified version of test_file_editor_happy_path from tests/integration/editor/test_basic_operations.py. Then ran pytest as described in the Readme. I had to disable test_peak_memory.py because it kept crashing (I think because I'm WSL). All tests passed.

## Does this PR introduce a breaking change?
No.
