### PR TITLE
Fix 'Is a directory' error in read_file method

### DIFF
--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -616,6 +616,10 @@ class OHEditor:
             end_line: Optional end line number (1-based). Must be provided with start_line.
             encoding: The encoding to use when reading the file (auto-detected by decorator)
         """
+        # Check if path is a directory before attempting to read
+        if path.is_dir():
+            raise ToolError(f'Cannot read {path}: it is a directory, not a file.')
+
         self.validate_file(path)
         try:
             if start_line is not None and end_line is not None:


### PR DESCRIPTION
## Problem
The `read_file` method in `OHEditor` could trigger `[Errno 21] Is a directory: '/path/to/directory'` when called directly on directory paths. This occurred because the method attempted to open directories as files without checking if the path is a directory first.

## Root Cause
- The `validate_file` method returns early for directories without validation
- The `read_file` method then tries to `open(path, 'r', encoding=encoding)` on the directory
- This causes the cryptic "Is a directory" error

## Solution
Added a directory check using `path.is_dir()` at the beginning of the `read_file` method before attempting to read the file. This provides a clear, user-friendly error message instead of the system-level errno.

## Changes
- Added 4 lines to `read_file` method in `openhands_aci/editor/editor.py`
- Check if path is a directory before attempting to read
- Raise `ToolError` with clear message: "Cannot read {path}: it is a directory, not a file."

## Testing
- ✅ Verified fix prevents the "Is a directory" error
- ✅ Confirmed normal file operations still work correctly  
- ✅ All existing tests pass (encoding tests, error handling tests, integration tests)
- ✅ Pre-commit hooks pass

## Error Message Comparison
**Before:** `Ran into [Errno 21] Is a directory: '/path/to/directory' while trying to read /path/to/directory`

**After:** `Cannot read /path/to/directory: it is a directory, not a file.`

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e90aad2b4da74008818309db9fa56637)