### PR TITLE
GeminiEditor (Phase 1a): Gemini-CLI–style replace with EOL preservation and expected_replacements

### DIFF
--- a/openhands_aci/editor/__init__.py
+++ b/openhands_aci/editor/__init__.py
@@ -8,10 +8,13 @@ from .file_cache import FileCache
 from .results import ToolResult
 
 _GLOBAL_EDITOR = OHEditor()
+from .gemini_editor import GeminiEditor
+
 
 __all__ = [
     'Command',
     'OHEditor',
+    'GeminiEditor',
     'ToolError',
     'ToolResult',
     'FileCache',

--- a/openhands_aci/editor/gemini_editor.py
+++ b/openhands_aci/editor/gemini_editor.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .editor import OHEditor
+from .exceptions import EditorToolParameterInvalidError, EditorToolParameterMissingError, ToolError
+from .results import CLIResult
+
+
+@dataclass
+class ReplaceResult:
+    count: int
+    prev_exist: bool
+    old_content: str
+    new_content: str
+
+
+class GeminiEditor(OHEditor):
+    """
+    Gemini-CLI–compatible editor subset for filesystem operations used by Gemini models.
+
+    Currently implements only the `replace` command with behavior aligned to Gemini CLI:
+    - Literal replacement with CRLF -> LF normalization when matching
+    - Error if old_string == new_string
+    - If old_string == '' and file does not exist: create file with new_string
+    - If file does not exist and old_string != '': error
+    - expected_replacements default = 1; enforce exact match count; error on 0 or mismatch
+    """
+
+    TOOL_NAME = 'gemini_editor'
+
+    def __call__(
+        self,
+        *,
+        command: str,
+        path: str,
+        old_str: str | None = None,
+        new_str: str | None = None,
+        expected_replacements: int | None = None,
+        **_: object,
+    ) -> CLIResult:
+        _path = Path(path)
+        if not _path.is_absolute():
+            raise EditorToolParameterInvalidError(
+                'path', path, 'The path should be an absolute path, starting with `/`.'
+            )
+        # Enforce workspace boundary if configured
+        if getattr(self, '_cwd', None) is not None:
+            try:
+                if not _path.resolve().is_relative_to(self._cwd):  # type: ignore[arg-type]
+                    raise EditorToolParameterInvalidError(
+                        'path', path, f'Path must be inside the workspace root: {self._cwd}'
+                    )
+            except Exception:
+                # Fallback: basic prefix check if resolve/is_relative_to not available
+                if not str(_path.resolve()).startswith(str(self._cwd)):
+                    raise EditorToolParameterInvalidError(
+                        'path', path, f'Path must be inside the workspace root: {self._cwd}'
+                    )
+        if command != 'replace':
+            raise ToolError(
+                f'Unrecognized command {command}. The allowed command for the {self.TOOL_NAME} tool is: replace.'
+            )
+        if new_str is None:
+            raise EditorToolParameterMissingError('replace', 'new_string')
+        if old_str is None:
+            old_str = ''
+        # Disallow directories
+        if _path.is_dir():
+            raise EditorToolParameterInvalidError(
+                'path', path, f'The path {path} is a directory and only the `view` command can be used on directories.'
+            )
+
+        return self._replace(_path, old_str, new_str, expected_replacements)
+
+    def _replace(
+        self,
+        path: Path,
+        old: str,
+        new: str,
+        expected: int | None,
+    ) -> CLIResult:
+        if new == old:
+            raise EditorToolParameterInvalidError(
+                'new_string', new, 'No replacement performed: new_string and old_string are identical.'
+            )
+
+        # File existence handling
+        if not path.exists():
+            if old == '':
+                # Create new file with new_string content
+                self.write_file(path, new)
+                self._history_manager.add_history(path, '')
+                return CLIResult(
+                    output=f'File created successfully at: {path}',
+                    path=str(path),
+                    prev_exist=False,
+                    old_content='',
+                    new_content=new,
+                )
+            else:
+                raise ToolError(f'The path {path} does not exist. Please provide a valid path.')
+
+        # Read raw content and normalize only for matching
+        raw_text = self.read_file(path)
+        normalized_text = raw_text.replace('\r\n', '\n').replace('\r', '\n')
+
+        if old == '':
+            # Creating into existing file is ambiguous; align to error
+            raise EditorToolParameterInvalidError(
+                'old_string', old, 'old_string cannot be empty when the file already exists.'
+            )
+
+        count = normalized_text.count(old)
+        if expected is None:
+            expected = 1
+
+        if count == 0:
+            raise ToolError(
+                f'No replacement was performed; old_string did not appear in {path}.'
+            )
+        if count != expected:
+            raise ToolError(
+                f'Expected {expected} replacements, but found {count} occurrences. Please refine your old_string or adjust expected_replacements.'
+            )
+
+        replaced_normalized = normalized_text.replace(old, new)
+
+        # Restore original line endings style
+        if '\r\n' in raw_text:
+            new_text = replaced_normalized.replace('\n', '\r\n')
+        elif '\r' in raw_text and '\n' not in raw_text:
+            new_text = replaced_normalized.replace('\n', '\r')
+        else:
+            new_text = replaced_normalized
+
+        # Persist changes
+        self._history_manager.add_history(path, raw_text)
+        self.write_file(path, new_text)
+
+        success_message = f'Replaced {count} occurrence(s) in {path}.\nReview the changes and ensure they are as expected.'
+        return CLIResult(
+            output=success_message,
+            path=str(path),
+            prev_exist=True,
+            old_content=raw_text,
+            new_content=new_text,
+        )

--- a/tests/unit/editor/test_gemini_editor.py
+++ b/tests/unit/editor/test_gemini_editor.py
@@ -1,0 +1,101 @@
+from pathlib import Path
+
+import pytest
+
+from openhands_aci.editor.gemini_editor import GeminiEditor
+from openhands_aci.editor.exceptions import EditorToolParameterInvalidError, ToolError
+
+
+def write_text(path: Path, content: str, eol='\n'):
+    # Normalize to requested eol when writing for test setup
+    content = content.replace('\n', eol)
+    path.write_text(content)
+
+
+def read_bytes(path: Path) -> bytes:
+    return path.read_bytes()
+
+
+def test_replace_single_occurrence(tmp_path):
+    p = tmp_path / 'a.txt'
+    p.write_text('hello\nworld\n')
+    ed = GeminiEditor(workspace_root=str(tmp_path))
+    res = ed(command='replace', path=str(p), old_str='world', new_str='there')
+    assert res.error is None
+    assert res.prev_exist is True
+    assert res.old_content == 'hello\nworld\n'
+    assert res.new_content == 'hello\nthere\n'
+
+
+def test_replace_mismatch_expected_count(tmp_path):
+    p = tmp_path / 'b.txt'
+    p.write_text('x x x\n')
+    ed = GeminiEditor(workspace_root=str(tmp_path))
+    res = ed(command='replace', path=str(p), old_str='x', new_str='y', expected_replacements=2)
+    assert res.error is not None
+    assert 'expected 2 occurrences but found 3' in res.error.lower()
+
+
+def test_replace_zero_occurrence_error(tmp_path):
+    p = tmp_path / 'c.txt'
+    p.write_text('abc\n')
+    ed = GeminiEditor(workspace_root=str(tmp_path))
+    res = ed(command='replace', path=str(p), old_str='zzz', new_str='mmm')
+    assert res.error is not None
+    assert '0 occurrences found' in res.error.lower()
+
+
+def test_replace_old_equals_new_error(tmp_path):
+    p = tmp_path / 'd.txt'
+    p.write_text('same\n')
+    ed = GeminiEditor(workspace_root=str(tmp_path))
+    res = ed(command='replace', path=str(p), old_str='same', new_str='same')
+    assert res.error is not None
+    assert 'new_string must be different from old_string' in res.error.lower()
+
+
+def test_replace_create_when_missing_and_old_empty(tmp_path):
+    p = tmp_path / 'new.txt'
+    ed = GeminiEditor(workspace_root=str(tmp_path))
+    assert not p.exists()
+    res = ed(command='replace', path=str(p), old_str='', new_str='content')
+    assert res.error is None
+    assert p.exists()
+    assert p.read_text() == 'content'
+
+
+def test_replace_missing_file_and_old_not_empty_error(tmp_path):
+    p = tmp_path / 'missing.txt'
+    ed = GeminiEditor(workspace_root=str(tmp_path))
+    res = ed(command='replace', path=str(p), old_str='x', new_str='y')
+    assert res.error is not None
+    assert 'file does not exist' in res.error.lower()
+
+
+def test_crlf_normalization_and_preservation(tmp_path):
+    p = tmp_path / 'crlf.txt'
+    # Write with CRLF
+    write_text(p, 'A\nB\nC\n', eol='\r\n')
+    data_before = read_bytes(p)
+    ed = GeminiEditor(workspace_root=str(tmp_path))
+    res = ed(command='replace', path=str(p), old_str='B', new_str='X')
+    assert res.error is None
+    data_after = read_bytes(p)
+    # File should still contain CRLFs and same number of bytes change as expected
+    assert b'\r\n' in data_after
+    assert data_before != data_after
+
+
+def test_enforce_workspace_boundary(tmp_path):
+    outside = Path('/tmp/outside.txt')
+    ed = GeminiEditor(workspace_root=str(tmp_path))
+    res = ed(command='replace', path=str(outside), old_str='', new_str='x')
+    assert res.error is not None
+    assert 'workspace root' in res.error.lower()
+
+
+def test_directory_path_rejected(tmp_path):
+    ed = GeminiEditor(workspace_root=str(tmp_path))
+    res = ed(command='replace', path=str(tmp_path), old_str='a', new_str='b')
+    assert res.error is not None
+    assert 'is a directory' in res.error.lower()


### PR DESCRIPTION
Scope: Phase 1a of Gemini-CLI compatible editor semantics.

Changes
- New GeminiEditor implementing replace semantics similar to Gemini-CLI:
  - Normalize match on LF; preserve original EOLs when writing.
  - Error if new_string == old_string.
  - If file missing and old_string == '': create file with new_string.
  - If file missing and old_string != '': error.
  - Enforce expected_replacements (default 1); error on 0 or mismatch.
  - Enforce absolute path, workspace root boundary; reject directories.
  - Return old/new file content to enable accurate diffs upstream.
- Export GeminiEditor in openhands_aci/editor/__init__.py.
- Unit tests covering success, mismatch, zero, old==new, EOL preservation, workspace boundary, directory rejection.

Why
- Gemini models benefit from Gemini-CLI tuned file edit semantics.

Companion PR
- OpenHands companion routes replace to GeminiEditor and exposes Gemini-only tools for Gemini models.

Co-authored-by: OpenHands-GPT-5 openhands@all-hands.dev