### PR TITLE
Clamp view_range end to file length and emit warning instead of error (fixes #154)

### DIFF
--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -348,22 +348,20 @@ class OHEditor:
                 f'Its first element `{start_line}` should be within the range of lines of the file: {[1, num_lines]}.',
             )
 
-        if end_line > num_lines:
-            raise EditorToolParameterInvalidError(
-                'view_range',
-                view_range,
-                f'Its second element `{end_line}` should be smaller than the number of lines in the file: `{num_lines}`.',
-            )
+        # Normalize end_line and provide a warning if it exceeds file length
+        warning_message: str | None = None
+        if end_line == -1:
+            end_line = num_lines
+        elif end_line > num_lines:
+            warning_message = f"We only show up to {num_lines} since there's only {num_lines} lines in this file"
+            end_line = num_lines
 
-        if end_line != -1 and end_line < start_line:
+        if end_line < start_line:
             raise EditorToolParameterInvalidError(
                 'view_range',
                 view_range,
                 f'Its second element `{end_line}` should be greater than or equal to the first element `{start_line}`.',
             )
-
-        if end_line == -1:
-            end_line = num_lines
 
         file_content = self.read_file(path, start_line=start_line, end_line=end_line)
 
@@ -371,6 +369,10 @@ class OHEditor:
         output = self._make_output(
             '\n'.join(file_content.splitlines()), str(path), start_line
         )  # Remove extra newlines
+
+        # Append warning if we truncated the end_line
+        if warning_message:
+            output += f'\nNOTE: {warning_message}\n'
 
         return CLIResult(
             path=str(path),

--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -353,7 +353,7 @@ class OHEditor:
         if end_line == -1:
             end_line = num_lines
         elif end_line > num_lines:
-            warning_message = f"We only show up to {num_lines} since there's only {num_lines} lines in this file"
+            warning_message = f"We only show up to {num_lines} since there're only {num_lines} lines in this file."
             end_line = num_lines
 
         if end_line < start_line:

--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -372,7 +372,7 @@ class OHEditor:
 
         # Prepend warning if we truncated the end_line
         if warning_message:
-            output = f'NOTE: {warning_message}\n\n{output}'
+            output = f'NOTE: {warning_message}\n{output}'
 
         return CLIResult(
             path=str(path),

--- a/openhands_aci/editor/editor.py
+++ b/openhands_aci/editor/editor.py
@@ -370,9 +370,9 @@ class OHEditor:
             '\n'.join(file_content.splitlines()), str(path), start_line
         )  # Remove extra newlines
 
-        # Append warning if we truncated the end_line
+        # Prepend warning if we truncated the end_line
         if warning_message:
-            output += f'\nNOTE: {warning_message}\n'
+            output = f'NOTE: {warning_message}\n\n{output}'
 
         return CLIResult(
             path=str(path),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openhands-aci"
-version = "0.3.1"
+version = "0.3.2"
 description = "An Agent-Computer Interface (ACI) designed for software development agents OpenHands."
 authors = ["OpenHands"]
 license = "MIT"

--- a/tests/integration/editor/test_error_handling.py
+++ b/tests/integration/editor/test_error_handling.py
@@ -86,7 +86,7 @@ def test_view_range_validation(temp_file):
         'should be a list of two integers' in result_json['formatted_output_and_error']
     )
 
-    # Test out of bounds range
+    # Test out of bounds range: should clamp to file end and show a warning
     result = file_editor(
         command='view',
         path=temp_file,
@@ -94,10 +94,7 @@ def test_view_range_validation(temp_file):
         enable_linting=False,
     )
     result_json = parse_result(result)
-    assert (
-        'should be smaller than the number of lines'
-        in result_json['formatted_output_and_error']
-    )
+    assert 'NOTE: We only show up to 3 since there\'s only 3 lines in this file' in result_json['formatted_output_and_error']
 
     # Test invalid range order
     result = file_editor(

--- a/tests/integration/editor/test_error_handling.py
+++ b/tests/integration/editor/test_error_handling.py
@@ -94,7 +94,7 @@ def test_view_range_validation(temp_file):
         enable_linting=False,
     )
     result_json = parse_result(result)
-    assert 'NOTE: We only show up to 3 since there\'s only 3 lines in this file' in result_json['formatted_output_and_error']
+    assert 'NOTE: We only show up to 3 since there\'re only 3 lines in this file.' in result_json['formatted_output_and_error']
 
     # Test invalid range order
     result = file_editor(


### PR DESCRIPTION
Summary
- Change OHEditor.view to clamp end_line to the file's length when the provided view_range end is beyond EOF.
- Preserve -1 semantics (end of file).
- Append a clear NOTE warning to the output when clamping occurs instead of raising an error.

Why
Fixes #154: Previously, requesting a range beyond EOF raised an error. The desired behavior is to show up to the end of the file and warn the user.

Changes
- openhands_aci/editor/editor.py
  - Normalize end_line: if -1 use EOF; if > num_lines, cap to num_lines and set a warning message.
  - Ensure end_line >= start_line after normalization.
  - Append a NOTE: We only show up to {num_lines} since there's only {num_lines} lines in this file when clamping occurs.
- tests/integration/editor/test_error_handling.py
  - Update out-of-bounds test to assert on NOTE warning instead of the old error message.

Testing
- Ran selective tests due to environment memory constraints:
  - tests/integration/editor/test_error_handling.py: PASS
  - tests/integration/test_oh_editor.py: PASS
  - tests/integration/editor/test_non_utf8_operations.py: PASS
- pre-commit hooks (ruff, format, mypy) all passed.

Notes
- Full pytest run hit a container MemoryError unrelated to these changes; the relevant tests covering the change pass.

Co-authored-by: openhands <openhands@all-hands.dev>

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/187984bcd851401b9b266d4f55545a14)