### PR TITLE
Bump version from 0.3.2 to 0.3.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openhands-aci"
-version = "0.3.2"
+version = "0.3.3"
 description = "An Agent-Computer Interface (ACI) designed for software development agents OpenHands."
 authors = ["OpenHands"]
 license = "MIT"


### PR DESCRIPTION
## Description
Would like to release a new version with https://github.com/All-Hands-AI/openhands-aci/pull/163.

## Related Issue
Related https://github.com/OpenHands/OpenHands/issues/13080

## Motivation and Context
Github action to publish a new package currently fails https://github.com/All-Hands-AI/openhands-aci/actions/runs/22497052282 without the version bump.

## How Has This Been Tested?

## Does this PR introduce a breaking change?
No this is a version bump without any other code changes.